### PR TITLE
Adding aggregate Javadoc goal to top-level build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,5 +51,57 @@
        <module>abiquo</module>
        <module>oauth</module>
        <module>openstack</module>
-  </modules>
+    </modules>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila.maven-license-plugin</groupId>
+                <artifactId>maven-license-plugin</artifactId>
+                <version>1.9.0</version>
+                <configuration>
+                    <strictCheck>true</strictCheck>
+                    <encoding>${sourceEncoding}</encoding>
+                    <aggregate>true</aggregate>
+                    <header>project/src/etc/header.txt</header>
+                    <mapping>
+                        <clj>SEMICOLON_STYLE</clj>
+                    </mapping>
+                    <excludes>
+                        <exclude>**/src/**/resources/**</exclude>
+                        <exclude>**/LICENSE.txt</exclude>
+                        <exclude>**/NOTICE.txt</exclude>
+                        <exclude>**/README.md</exclude>
+                        <exclude>**/README.txt</exclude>
+                        <exclude>**/header.txt</exclude>
+                    </excludes>
+                    <properties>
+                        <year>2011</year>
+                        <copyrightHolder>jclouds, Inc.</copyrightHolder>
+                    </properties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>doc</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>javadoc</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>aggregate-jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Needed so we can publish Javadocs for HEAD. Also added the license checker - same code as in the main [aggregate POM](https://github.com/jclouds/jclouds/blob/master/pom.xml).
