### PR TITLE
Add jclouds-dto project

### DIFF
--- a/jclouds-management/README.md
+++ b/jclouds-management/README.md
@@ -1,0 +1,39 @@
+jclouds management
+=======================
+
+This project provides integration of jclouds with JMX.
+
+Jclouds Managed Beans
+---------------------
+
+The project provides 3 kind of MBeans:
+
+* **JcloudsManagementMBean** (single) Exposes Apis, Providers & Contexts. Additionally provides methods for creating Contexts.
+* **ComputeServiceManagementMBean** (per context) Exposes all ComputeService operations via JMX.
+* **BlobstoreManagementMBean** (per context) Exposes all Blobstore operations via JMX.
+
+
+The ManagementContext
+---------------------
+
+The ManagementContext is resoposible for keeping track of the MBeanServer, MBean and Contexts LifeCycle.
+The default implementation is the BaseManagementContext and it provides method for binding and unbinding an MBeanServer and also jclouds ManagedBean.
+
+Below is an example that create the ManagementContext and registers the core jclouds management bean.
+
+    ManagementContext managementContext = new BaseManagementContext();
+    JcloudsManagementMBean jcloudsManagement = new JcloudsManagement();
+    managementContext.manage(jcloudsManagement);
+
+This will expose via JMX the available Apis, Providers and Contexts. Also it will provide managed methods for creating a Context.
+When used inside OSGi the BaseManagementContext is registered as a service, JcloudsManagementMBean will be autoregistered and it will transparently track MBeanServer changes.
+
+The ManagementLifeCycle module
+-------------------------------
+
+The jclouds management project provides a guice module called ManagementLifecycle. This module can be passed to the ContextBuilder in order to expose mbeans for the created contexts.
+
+    ManagmenetContext managementContext = new BaseManagementContext();
+    ContextBuilder.newBuilder(providerOrApi).modules(ImmutableSet.of(new ManagementLifecycle(managementContext)).build();
+
+

--- a/jclouds-management/management-blobstore/pom.xml
+++ b/jclouds-management/management-blobstore/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to jclouds, Inc. (jclouds) under one or more
+   contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  jclouds licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>jclouds-management</artifactId>
+        <groupId>org.jclouds.labs</groupId>
+        <version>1.7.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jclouds.labs.management</groupId>
+    <artifactId>management-blobstore</artifactId>
+    <packaging>bundle</packaging>
+    <name>jclouds :: management :: blobstore</name>
+
+    <properties>
+        <jclouds.osgi.import>
+            *
+        </jclouds.osgi.import>
+        <jclouds.osgi.export>
+            org.jclouds.management.blobstore*;version="${project.version}";-noimport:=true
+        </jclouds.osgi.export>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jclouds</groupId>
+            <artifactId>jclouds-blobstore</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jclouds.labs.representations</groupId>
+            <artifactId>representations-codec</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jclouds.labs.management</groupId>
+            <artifactId>management-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>14.0.1</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jclouds-management/management-blobstore/src/main/java/org/jclouds/blobstore/management/BlobStoreManagement.java
+++ b/jclouds-management/management-blobstore/src/main/java/org/jclouds/blobstore/management/BlobStoreManagement.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.blobstore.management;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableSet;
+import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.BlobStoreContext;
+import org.jclouds.blobstore.codec.ToBlob;
+import org.jclouds.blobstore.codec.ToBlobMetadata;
+import org.jclouds.blobstore.codec.ToStorageMetadata;
+import org.jclouds.blobstore.options.ListContainerOptions;
+import org.jclouds.codec.ToLocation;
+import org.jclouds.management.ViewMBean;
+import org.jclouds.representations.Location;
+import org.jclouds.blobstore.representations.Blob;
+import org.jclouds.blobstore.representations.BlobMetadata;
+import org.jclouds.blobstore.representations.StorageMetadata;
+import org.jclouds.javax.annotation.Nullable;
+
+import java.util.Set;
+
+import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Iterables.tryFind;
+
+public class BlobStoreManagement implements BlobStoreManagementMBean, ViewMBean<BlobStoreContext> {
+
+   private final BlobStore blobStore;
+
+   public BlobStoreManagement(BlobStoreContext context) {
+      this.blobStore = context.getBlobStore();
+   }
+
+   @Override
+   public Set<Location> listAssignableLocations() {
+      return ImmutableSet.<Location>builder()
+                         .addAll(transform(blobStore.listAssignableLocations(), ToLocation.INSTANCE))
+                         .build();
+   }
+
+   @Override
+   public Set<StorageMetadata> list() {
+      return ImmutableSet.<StorageMetadata>builder()
+                         .addAll(transform(blobStore.list(), ToStorageMetadata.INSTANCE))
+                         .build();
+   }
+
+   @Override
+   public Set<StorageMetadata> list(String container) {
+      return ImmutableSet.<StorageMetadata>builder()
+                         .addAll(transform(blobStore.list(container), ToStorageMetadata.INSTANCE))
+                         .build();
+   }
+
+   @Override
+   public Set<StorageMetadata> list(String container, String directory) {
+      return ImmutableSet.<StorageMetadata>builder()
+              .addAll(transform(blobStore.list(container, ListContainerOptions.Builder.inDirectory(directory)), ToStorageMetadata.INSTANCE))
+              .build();
+   }
+
+   @Override
+   public BlobMetadata blobMetadata(String container, String name) {
+      return ToBlobMetadata.INSTANCE.apply(blobStore.blobMetadata(container, name));
+   }
+
+   @Override
+   public Blob getBlob(String container, String name) {
+      return ToBlob.INSTANCE.apply(blobStore.getBlob(container, name));
+   }
+
+   @Override
+   public boolean containerExists(String container) {
+      return blobStore.containerExists(container);
+   }
+
+   @Override
+   public boolean createContainerInLocation(@Nullable String locationId, String container) {
+      Optional<? extends org.jclouds.domain.Location> location = tryFind(blobStore.listAssignableLocations(), new LocationPredicate(locationId));
+
+      if (location.isPresent()) {
+         return blobStore.createContainerInLocation(location.get(), container);
+      } else {
+         return false;
+      }
+   }
+
+   @Override
+   public void clearContainer(String container) {
+      blobStore.clearContainer(container);
+   }
+
+   @Override
+   public void deleteContainer(String container) {
+      blobStore.deleteContainer(container);
+   }
+
+   @Override
+   public boolean directoryExists(String container, String directory) {
+      return blobStore.directoryExists(container, directory);
+   }
+
+   @Override
+   public void createDirectory(String container, String directory) {
+      blobStore.createDirectory(container, directory);
+   }
+
+   @Override
+   public void deleteDirectory(String containerName, String name) {
+      blobStore.deleteDirectory(containerName, name);
+   }
+
+   @Override
+   public boolean blobExists(String container, String name) {
+      return blobStore.blobExists(container, name);
+   }
+
+   @Override
+   public void removeBlob(String container, String name) {
+      blobStore.removeBlob(container, name);
+   }
+
+   @Override
+   public long countBlobs(String container) {
+      return blobStore.countBlobs(container);
+   }
+
+   @Override
+   public String getType() {
+      return "blobstore";
+   }
+
+   private static final class LocationPredicate implements Predicate<org.jclouds.domain.Location> {
+      private final String id;
+
+      private LocationPredicate(String id) {
+         this.id = id;
+      }
+
+      @Override
+      public boolean apply(@Nullable org.jclouds.domain.Location input) {
+         return input.getId().equals(id);
+      }
+   }
+}

--- a/jclouds-management/management-blobstore/src/main/java/org/jclouds/blobstore/management/BlobStoreManagementMBean.java
+++ b/jclouds-management/management-blobstore/src/main/java/org/jclouds/blobstore/management/BlobStoreManagementMBean.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.blobstore.management;
+
+import org.jclouds.blobstore.representations.BlobStore;
+
+public interface BlobStoreManagementMBean extends BlobStore {
+
+
+}

--- a/jclouds-management/management-blobstore/src/main/java/org/jclouds/blobstore/management/BlobStoreViewMBeanFactory.java
+++ b/jclouds-management/management-blobstore/src/main/java/org/jclouds/blobstore/management/BlobStoreViewMBeanFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.blobstore.management;
+
+import com.google.common.reflect.TypeToken;
+import org.jclouds.blobstore.BlobStoreContext;
+import org.jclouds.management.ViewMBean;
+import org.jclouds.management.ViewMBeanFactory;
+
+public class BlobStoreViewMBeanFactory implements ViewMBeanFactory<BlobStoreContext> {
+
+   private static final TypeToken<BlobStoreContext> TYPE = TypeToken.of(BlobStoreContext.class);
+
+   /**
+    * Creates a {@link org.jclouds.management.ManagedBean} for the Context.
+    *
+    * @param view
+    * @return
+    */
+   @Override
+   public ViewMBean<BlobStoreContext> create(BlobStoreContext view) {
+      return new BlobStoreManagement(view);
+   }
+
+   /**
+    * Returns the {@link com.google.common.reflect.TypeToken} of the {@link org.jclouds.View}.
+    *
+    * @return
+    */
+   @Override
+   public TypeToken<BlobStoreContext> getViewType() {
+      return TYPE;
+   }
+}

--- a/jclouds-management/management-blobstore/src/main/resources/META-INF/services/org.jclouds.management.ViewMBeanFactory
+++ b/jclouds-management/management-blobstore/src/main/resources/META-INF/services/org.jclouds.management.ViewMBeanFactory
@@ -1,0 +1,1 @@
+org.jclouds.blobstore.management.BlobStoreViewMBeanFactory

--- a/jclouds-management/management-compute/pom.xml
+++ b/jclouds-management/management-compute/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to jclouds, Inc. (jclouds) under one or more
+   contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  jclouds licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>jclouds-management</artifactId>
+        <groupId>org.jclouds.labs</groupId>
+        <version>1.7.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jclouds.labs.management</groupId>
+    <artifactId>management-compute</artifactId>
+    <packaging>bundle</packaging>
+    <name>jclouds :: management :: compute</name>
+
+    <properties>
+        <jclouds.osgi.import>
+            *
+        </jclouds.osgi.import>
+        <jclouds.osgi.export>
+            org.jclouds.management.compute*;version="${project.version}";-noimport:=true
+        </jclouds.osgi.export>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jclouds</groupId>
+            <artifactId>jclouds-compute</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jclouds.labs.representations</groupId>
+            <artifactId>representations-codec</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jclouds.labs.management</groupId>
+            <artifactId>management-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>14.0.1</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jclouds-management/management-compute/src/main/java/org/jclouds/compute/management/ComputeServiceManagement.java
+++ b/jclouds-management/management-compute/src/main/java/org/jclouds/compute/management/ComputeServiceManagement.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.management;
+
+
+import com.google.common.collect.ImmutableSet;
+import org.jclouds.codec.ToLocation;
+import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.ComputeServiceContext;
+import org.jclouds.compute.codec.ToExecResponse;
+import org.jclouds.compute.codec.ToHardware;
+import org.jclouds.compute.codec.ToImage;
+import org.jclouds.compute.codec.ToNodeMetadata;
+import org.jclouds.compute.representations.ExecResponse;
+import org.jclouds.compute.representations.NodeMetadata;
+import org.jclouds.management.ViewMBean;
+import org.jclouds.representations.Location;
+import org.jclouds.compute.representations.Hardware;
+import org.jclouds.compute.representations.Image;
+
+import java.util.Set;
+
+import static com.google.common.collect.Iterables.transform;
+
+public class ComputeServiceManagement implements ComputeServiceManagementMBean, ViewMBean<ComputeServiceContext> {
+
+   private final ComputeService service;
+
+   public ComputeServiceManagement(ComputeServiceContext context) {
+      this.service = context.getComputeService();
+   }
+
+   @Override
+   public Set<Hardware> listHardwareProfiles() {
+      return ImmutableSet.<Hardware>builder()
+                         .addAll(transform(service.listHardwareProfiles(), ToHardware.INSTANCE))
+                         .build();
+   }
+
+   @Override
+   public Set<Image> listImages() {
+      return ImmutableSet.<Image>builder()
+                         .addAll(transform(service.listImages(), ToImage.INSTANCE))
+                         .build();
+   }
+
+   @Override
+   public Image getImage(String id)  {
+      return ToImage.INSTANCE.apply(service.getImage(id));
+   }
+
+   @Override
+   public Set<NodeMetadata> listNodes() {
+      return ImmutableSet.<NodeMetadata>builder()
+                         .addAll(transform( (Set<org.jclouds.compute.domain.NodeMetadata>) service.listNodes(), ToNodeMetadata.INSTANCE))
+                         .build();
+   }
+
+   @Override
+   public Set<Location> listAssignableLocations() {
+      return ImmutableSet.<Location>builder()
+                         .addAll(transform(service.listAssignableLocations(), ToLocation.INSTANCE))
+                         .build();
+   }
+
+   @Override
+   public void resumeNode(String id) {
+      service.resumeNode(id);
+   }
+
+   @Override
+   public void suspendNode(String id) {
+      service.suspendNode(id);
+   }
+
+
+   @Override
+   public void destroyNode(String id) {
+      service.destroyNode(id);
+   }
+
+
+   @Override
+   public void rebootNode(String id) {
+      service.destroyNode(id);
+   }
+
+   @Override
+   public NodeMetadata getNode(String id) {
+      return ToNodeMetadata.INSTANCE.apply(service.getNodeMetadata(id));
+   }
+
+   @Override
+   public ExecResponse runScriptOnNode(String id, String runScript) {
+      return ToExecResponse.INSTANCE.apply(service.runScriptOnNode(id, runScript));
+   }
+
+   @Override
+   public String getType() {
+      return "compute";
+   }
+}

--- a/jclouds-management/management-compute/src/main/java/org/jclouds/compute/management/ComputeServiceManagementMBean.java
+++ b/jclouds-management/management-compute/src/main/java/org/jclouds/compute/management/ComputeServiceManagementMBean.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.management;
+
+import org.jclouds.compute.representations.ComputeService;
+
+public interface ComputeServiceManagementMBean extends ComputeService {
+
+}

--- a/jclouds-management/management-compute/src/main/java/org/jclouds/compute/management/ComputeServiceViewMBeanFactory.java
+++ b/jclouds-management/management-compute/src/main/java/org/jclouds/compute/management/ComputeServiceViewMBeanFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.management;
+
+import com.google.common.reflect.TypeToken;
+import org.jclouds.compute.ComputeServiceContext;
+import org.jclouds.management.ViewMBean;
+import org.jclouds.management.ViewMBeanFactory;
+
+
+public class ComputeServiceViewMBeanFactory implements ViewMBeanFactory<ComputeServiceContext> {
+
+   private static final TypeToken<ComputeServiceContext> TYPE = TypeToken.of(ComputeServiceContext.class);
+   /**
+    * Creates a {@link org.jclouds.management.ManagedBean} for the Context.
+    *
+    * @param context
+    * @return
+    */
+   @Override
+   public ViewMBean<ComputeServiceContext> create(ComputeServiceContext context) {
+      return new ComputeServiceManagement(context);
+   }
+
+   /**
+    * Returns the {@link com.google.common.reflect.TypeToken} of the {@link org.jclouds.View}.
+    *
+    * @return
+    */
+   @Override
+   public TypeToken<ComputeServiceContext> getViewType() {
+      return  TYPE;
+   }
+}

--- a/jclouds-management/management-compute/src/main/resources/META-INF/services/org.jclouds.management.ViewMBeanFactory
+++ b/jclouds-management/management-compute/src/main/resources/META-INF/services/org.jclouds.management.ViewMBeanFactory
@@ -1,0 +1,1 @@
+org.jclouds.compute.management.ComputeServiceViewMBeanFactory

--- a/jclouds-management/management-core/pom.xml
+++ b/jclouds-management/management-core/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to jclouds, Inc. (jclouds) under one or more
+   contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  jclouds licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>jclouds-management</artifactId>
+        <groupId>org.jclouds.labs</groupId>
+        <version>1.7.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jclouds.labs.management</groupId>
+    <artifactId>management-core</artifactId>
+    <packaging>bundle</packaging>
+    <name>jclouds :: management :: core</name>
+
+    <properties>
+        <jclouds.osgi.import>
+            *
+        </jclouds.osgi.import>
+        <jclouds.osgi.export>
+            org.jclouds.management*;version="${project.version}";-noimport:=true
+        </jclouds.osgi.export>
+        <jclouds.osgi.activator>org.jclouds.management.osgi.Activator</jclouds.osgi.activator>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jclouds</groupId>
+            <artifactId>jclouds-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jclouds.labs.representations</groupId>
+            <artifactId>representations-codec</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>14.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>4.2.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+            <version>4.2.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Testing Dependencies -->
+        <dependency>
+            <groupId>org.jclouds</groupId>
+            <artifactId>jclouds-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jclouds-management/management-core/src/main/java/org/jclouds/management/JcloudsManagement.java
+++ b/jclouds-management/management-core/src/main/java/org/jclouds/management/JcloudsManagement.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Closeables;
+import org.jclouds.ContextBuilder;
+import org.jclouds.apis.Apis;
+import org.jclouds.codec.ToApiMetadata;
+import org.jclouds.codec.ToContext;
+import org.jclouds.codec.ToProvider;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.management.config.ManagementLifecycle;
+import org.jclouds.management.internal.BaseManagementContext;
+import org.jclouds.providers.Providers;
+import org.jclouds.representations.ApiMetadata;
+import org.jclouds.representations.Context;
+import org.jclouds.representations.ProviderMetadata;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+import static com.google.common.collect.Iterables.transform;
+
+/**
+ * Core Jclouds MBean for displaying available {@link org.jclouds.representations.ApiMetadata}, {@link org.jclouds.representations.ProviderMetadata} and {@link org.jclouds.representations.Context}s.
+ * Also useful for creating contexts.
+ */
+public class JcloudsManagement implements JcloudsManagementMBean, ManagedBean {
+
+   private final ManagementContext managementContext;
+
+   public JcloudsManagement() {
+      this(BaseManagementContext.INSTANCE);
+   }
+
+   public JcloudsManagement(ManagementContext managementContext) {
+      this.managementContext = managementContext;
+   }
+
+   @Override
+   public Iterable<ApiMetadata> getApis() {
+      return ImmutableSet.<ApiMetadata>builder()
+              .addAll(transform(Apis.all(), ToApiMetadata.INSTANCE))
+              .build();
+   }
+
+   @Override
+   public ApiMetadata findApiById(String id) {
+      return ToApiMetadata.INSTANCE.apply(Apis.withId(id));
+   }
+
+   @Override
+   public Iterable<ProviderMetadata> getProviders() {
+      return ImmutableSet.<ProviderMetadata>builder()
+              .addAll(transform(Providers.all(), ToProvider.INSTANCE))
+              .build();
+   }
+
+   @Override
+   public ProviderMetadata findProviderById(String id) {
+      return ToProvider.INSTANCE.apply(Providers.withId(id));
+   }
+
+   @Override
+   public Iterable<Context> getContexts() {
+      return ImmutableSet.<Context>builder()
+              .addAll(transform(managementContext.listContexts(), ToContext.INSTANCE))
+              .build();
+   }
+
+   @Override
+   public Context createContext(String id, String name, String identity, String credential, String endpoint, String overrides) throws IOException {
+      return ToContext.INSTANCE.apply(
+              ContextBuilder.newBuilder(id).name(name).credentials(identity, credential).endpoint(endpoint)
+                      .modules(ImmutableSet.of(new ManagementLifecycle(BaseManagementContext.INSTANCE)))
+                      .overrides(stringToProperties(overrides))
+                      .build()
+      );
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public String getType() {
+      return "management";
+   }
+
+   /**
+    * Parses the String into a {@link Properties} object.
+    * The String is expected to separated key from valus using the '=' sign and key/value pairs with a new line.
+    * @param input
+    * @return
+    * @throws IOException
+    */
+   private static Properties stringToProperties(@Nullable String input) throws IOException {
+      Properties properties = new Properties();
+      if (!Strings.isNullOrEmpty(input)) {
+         ByteArrayInputStream bis = null;
+         try {
+            bis = new ByteArrayInputStream(input.getBytes(Charsets.UTF_8));
+            properties.load(bis);
+         } finally {
+            Closeables.close(bis, true);
+         }
+      }
+      return properties;
+   }
+}

--- a/jclouds-management/management-core/src/main/java/org/jclouds/management/JcloudsManagementMBean.java
+++ b/jclouds-management/management-core/src/main/java/org/jclouds/management/JcloudsManagementMBean.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management;
+
+
+import org.jclouds.representations.ApiMetadata;
+import org.jclouds.representations.Context;
+import org.jclouds.representations.ProviderMetadata;
+
+import java.io.IOException;
+
+
+public interface JcloudsManagementMBean {
+
+   /**
+    * Lists all available {@link org.jclouds.representations.ApiMetadata}.
+    * @return
+    */
+   Iterable<ApiMetadata> getApis();
+
+   /**
+    * Find {@link org.jclouds.representations.ApiMetadata} by id.
+    * @return
+    */
+   ApiMetadata findApiById(String id);
+
+
+   /**
+    * Lists all available {@link org.jclouds.representations.ProviderMetadata}
+    * @return
+    */
+   Iterable<ProviderMetadata> getProviders();
+
+
+   /**
+    * Find {@link org.jclouds.representations.ProviderMetadata} by id.
+    * @return
+    */
+   ProviderMetadata findProviderById(String id);
+
+   /**
+    * Lists all {@link org.jclouds.representations.Context} objects.
+    * @return
+    */
+   Iterable<Context> getContexts();
+
+   /**
+    * Creates a {@link org.jclouds.representations.Context}.
+    * @param id
+    * @param name
+    * @param identity
+    * @param credential
+    * @param endpoint
+    * @param overrides     The override properties as a list of new line separated key value pairs. Key/Values are separated by the equals sign.
+    * @return
+    */
+   Context createContext(String id, String name, String identity, String credential, String endpoint, String overrides) throws IOException;
+}

--- a/jclouds-management/management-core/src/main/java/org/jclouds/management/ManagedBean.java
+++ b/jclouds-management/management-core/src/main/java/org/jclouds/management/ManagedBean.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management;
+
+/**
+ * An interface that describes jclouds managed beans.
+ * It's used for generating the {@link javax.management.ObjectName}.
+ */
+public interface ManagedBean {
+
+   /**
+    * Returns the type of the MBean.
+    * @return
+    */
+   String getType();
+
+}

--- a/jclouds-management/management-core/src/main/java/org/jclouds/management/ManagementContext.java
+++ b/jclouds-management/management-core/src/main/java/org/jclouds/management/ManagementContext.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management;
+
+import org.jclouds.Context;
+import org.jclouds.View;
+
+import javax.management.MBeanServer;
+
+/**
+ * The management context, keeps track of the {@link ManagedBean} objects that have been created.
+ * It is responsible for exporting beans to the {@link javax.management.MBeanServer}, whenever it becomes available.
+ * It also keeps track of {@link View}s created, so that they can be accessed via JMX.
+ */
+public interface ManagementContext {
+
+   /**
+    * Register a {@link ManagedBean} to the MBeanServer.
+    * @param mBean   The ManagedBean to add to the context.
+    * @param name    The name under which the bean will be exposed.
+    */
+   void manage(ManagedBean mBean, String name);
+
+   /**
+    * Un-registers a {@link ManagedBean} to the MBeanServer.
+    * @param mBean   The ManagedBean to remove from the context.
+    * @param name    The name under which the bean was exposed.
+    */
+   void unmanage(ManagedBean mBean, String name);
+
+
+   /**
+    * Bind an {@link javax.management.MBeanServer} to the context.
+    * This is mostly useful for dynamic environments where an {@link javax.management.MBeanServer} may come and go.
+    * The context should re-register the {@link ManagedBean} objects that have been added to the context.
+    * @param mBeanServer
+    */
+   void bind(MBeanServer mBeanServer);
+
+   /**
+    * Unbind an {@link javax.management.MBeanServer} to the context.
+    * This is mostly useful for dynamic environments where an {@link javax.management.MBeanServer} may come and go.
+    * The context should unregister the {@link ManagedBean} objects that have been added to the context.
+    * @param mBeanServer
+    */
+   void unbind(MBeanServer mBeanServer);
+
+   /**
+    * Register {@link org.jclouds.View}.
+    * @param view
+    * @param <V>
+    */
+   <V extends View> void register(V view);
+
+   /**
+    * Un-register {@link View}.
+    * @param view
+    * @param <V>
+    */
+   <V extends View> void unregister(V view);
+
+   /**
+    * List all registered {@link Context} objects.
+    * @return
+    */
+   Iterable<? extends Context> listContexts();
+
+
+   /**
+    * Returns {@link Context} by name.
+    * @param name
+    * @param <C>
+    */
+   <C extends Context> C getContext(String name);
+
+}

--- a/jclouds-management/management-core/src/main/java/org/jclouds/management/ViewMBean.java
+++ b/jclouds-management/management-core/src/main/java/org/jclouds/management/ViewMBean.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management;
+
+import org.jclouds.View;
+
+/**
+ * A {@link ManagedBean} type for managing {@link View}s.
+ * @param <V>
+ */
+public interface ViewMBean<V extends View> extends ManagedBean {
+}

--- a/jclouds-management/management-core/src/main/java/org/jclouds/management/ViewMBeanFactories.java
+++ b/jclouds-management/management-core/src/main/java/org/jclouds/management/ViewMBeanFactories.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.TypeToken;
+import org.jclouds.management.osgi.ViewManagementFactoryRegistry;
+
+import java.util.ServiceLoader;
+
+import static com.google.common.collect.Iterables.filter;
+
+public class ViewMBeanFactories {
+
+   /**
+    * Returns the {@link ViewMBeanFactory} located on the classpath via {@link java.util.ServiceLoader}.
+    * @return all available factories loaded from classpath via  {@link java.util.ServiceLoader}
+    */
+   public static Iterable<ViewMBeanFactory> fromServiceLoader() {
+      return ServiceLoader.load(ViewMBeanFactory.class);
+   }
+
+   /**
+    * Returns the {@link ViewMBeanFactory} found via {@link org.jclouds.management.osgi.ViewManagementFactoryRegistry} and  {@link java.util.ServiceLoader}.
+    * @return all available factories.
+    */
+   public static Iterable<ViewMBeanFactory> all() {
+      return ImmutableSet.<ViewMBeanFactory>builder()
+              .addAll(fromServiceLoader())
+              .addAll(ViewManagementFactoryRegistry.fromRegistry()).build();
+   }
+
+   public static Iterable<ViewMBeanFactory> forType(TypeToken viewableAs) {
+      return filter(all(), ViewMBeanFactoryPredicates.forType(viewableAs));
+   }
+
+}

--- a/jclouds-management/management-core/src/main/java/org/jclouds/management/ViewMBeanFactory.java
+++ b/jclouds-management/management-core/src/main/java/org/jclouds/management/ViewMBeanFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management;
+
+import com.google.common.reflect.TypeToken;
+import org.jclouds.View;
+
+/**
+ * A factory for {@ViewManagement}.
+ * @param <V>
+ */
+public interface ViewMBeanFactory<V extends View> {
+
+   /**
+    * Creates a {@link ManagedBean} for the Context.
+    * @param view
+    * @return
+    */
+   ViewMBean<V> create(V view);
+
+   /**
+    * Returns the {@link TypeToken} of the {@link View}.
+    * @return
+    */
+   TypeToken<V> getViewType();
+}

--- a/jclouds-management/management-core/src/main/java/org/jclouds/management/ViewMBeanFactoryPredicates.java
+++ b/jclouds-management/management-core/src/main/java/org/jclouds/management/ViewMBeanFactoryPredicates.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management;
+
+import com.google.common.base.Predicate;
+import com.google.common.reflect.TypeToken;
+import org.jclouds.View;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ViewMBeanFactoryPredicates {
+
+   public static <V extends View> Predicate<ViewMBeanFactory<V>> forType(final TypeToken<V> type) {
+      checkNotNull(type, "type");
+      return new ViewMBeanFactoryForType<V>(type);
+   }
+
+   private static class ViewMBeanFactoryForType<V extends View> implements Predicate<ViewMBeanFactory<V>> {
+
+      private final TypeToken<V> type;
+
+      private ViewMBeanFactoryForType(TypeToken<V> type) {
+         this.type = type;
+      }
+
+      @Override
+      public boolean apply(ViewMBeanFactory factory) {
+         return factory.getViewType().isAssignableFrom(type);
+      }
+
+      @Override
+      public String toString() {
+         return "forType(" + type + ")";
+      }
+   }
+}

--- a/jclouds-management/management-core/src/main/java/org/jclouds/management/config/ManagementLifecycle.java
+++ b/jclouds-management/management-core/src/main/java/org/jclouds/management/config/ManagementLifecycle.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management.config;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import com.google.common.reflect.TypeToken;
+import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
+import com.google.inject.matcher.AbstractMatcher;
+import com.google.inject.matcher.Matcher;
+import com.google.inject.matcher.Matchers;
+import com.google.inject.spi.InjectionListener;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.spi.TypeListener;
+import org.jclouds.View;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.lifecycle.Closer;
+import org.jclouds.management.ManagementContext;
+import org.jclouds.management.ViewMBean;
+import org.jclouds.management.ViewMBeanFactories;
+import org.jclouds.management.ViewMBeanFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * A {@link com.google.inject.Module} for managing the lifecycle of {@link org.jclouds.management.ViewMBean} beans.
+ * The goal of this module is to create {@link org.jclouds.management.ViewMBean} beans that correspond to each {@link View} created/destroyed
+ * and register/un-register them to the {@link ManagementContext}.
+ */
+public class ManagementLifecycle extends AbstractModule {
+
+   private final ManagementContext managementContext;
+
+   public ManagementLifecycle(ManagementContext context) {
+      this.managementContext = context;
+   }
+
+   @Override
+   protected void configure() {
+      bindListener(subClassOf(View.class), new TypeListener() {
+         @Override
+         public <I> void hear(final TypeLiteral<I> typeLiteral, TypeEncounter<I> typeEncounter) {
+            typeEncounter.register(new InjectionListener<I>() {
+               @Override
+               public void afterInjection(Object object) {
+                  final View view = (View) object;
+                  final Iterable<ViewMBean> viewMamanagementBeans  = viewManagementOf(view);
+                  final Closer closer = view.unwrap().utils().injector().getInstance(Closer.class);
+                  //We get the name from the view and not from the view management object to avoid proxy issues.
+                  final String name = view.unwrap().getName();
+                  managementContext.register(view);
+
+                  //Manage the created management view objects to the context.
+                  for (ViewMBean viewMBean : viewMamanagementBeans) {
+                     managementContext.manage(viewMBean, name);
+                  }
+
+                  //Add the the management view objects to the Closer, so that they are unregistered on close.
+                  closer.addToClose(new Closeable() {
+                     @Override
+                     public void close() throws IOException {
+                        for (ViewMBean viewMBean : viewMamanagementBeans) {
+                           managementContext.unmanage(viewMBean, name);
+                        }
+                        managementContext.unregister(view);
+                     }
+                  });
+               }
+            });
+         }
+      });
+   }
+
+   /**
+    * Returns an {@link Iterable} of {@link org.jclouds.management.ViewMBean} for the specified {@link View}.
+    * @param view
+    * @return
+    */
+   private static Iterable<ViewMBean> viewManagementOf(final View view) {
+      TypeToken type = TypeToken.of(view.getClass());
+      return Iterables.transform(ViewMBeanFactories.forType(type), new Function<ViewMBeanFactory, ViewMBean>() {
+         @Override
+         public ViewMBean apply(@Nullable ViewMBeanFactory factory) {
+            return factory.create(view);
+         }
+      });
+   }
+
+   /**
+    * Creates a {@link TypeLiteral} {@link Matcher} for matching subclasses.
+    * This is for use in bindListener.
+    * @param clazz
+    * @return
+    */
+   private static Matcher<TypeLiteral> subClassOf(final Class<?> clazz) {
+      return new AbstractMatcher<TypeLiteral>() {
+         public boolean matches (TypeLiteral typeLiteral){
+            return Matchers.subclassesOf(clazz).matches(typeLiteral.getRawType());
+         }
+      };
+   }
+}

--- a/jclouds-management/management-core/src/main/java/org/jclouds/management/internal/BaseManagementContext.java
+++ b/jclouds-management/management-core/src/main/java/org/jclouds/management/internal/BaseManagementContext.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management.internal;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import org.jclouds.Context;
+import org.jclouds.View;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.management.ManagedBean;
+import org.jclouds.management.ManagementContext;
+
+import javax.management.MBeanServer;
+import java.lang.management.ManagementFactory;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public enum BaseManagementContext implements ManagementContext {
+
+   INSTANCE;
+
+   private final Map<String, View> views = Maps.newHashMap();
+   private final Map<Key, ManagedBean> mbeans = Maps.newHashMap();
+
+   //The MBeanServer can be bind/unbind (especially inside OSGi) so its not always available.
+   //Thus is represented as Optional.
+   private Optional<MBeanServer> mBeanServer = Optional.of(ManagementFactory.getPlatformMBeanServer());
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public synchronized void manage(ManagedBean mBean, String name) {
+      if (mBeanServer.isPresent()) {
+         ManagementUtils.register(mBeanServer.get(), mBean, mBean.getType(), name);
+      }
+      mbeans.put(new Key(mBean, name), mBean);
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public synchronized void unmanage(ManagedBean mBean, String name) {
+      if (mBeanServer.isPresent()) {
+         ManagementUtils.unregister(mBeanServer.get(), mBean.getType(), name);
+      }
+      mbeans.remove(new Key(mBean, name));
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public synchronized void bind(MBeanServer server) {
+      this.mBeanServer = Optional.of(server);
+      for(Map.Entry<Key, ManagedBean> entry : mbeans.entrySet()) {
+         String name = entry.getKey().getName();
+         ManagedBean mBean = entry.getValue();
+         ManagementUtils.register(server, mBean, mBean.getType(), name);
+      }
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public synchronized void unbind(MBeanServer server) {
+      for(Map.Entry<Key, ManagedBean> entry : mbeans.entrySet()) {
+         String name = entry.getKey().getName();
+         ManagedBean mBean = entry.getValue();
+         ManagementUtils.unregister(server, mBean.getType(), name);
+      }
+      this.mBeanServer = Optional.absent();
+   }
+
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public <V extends View> void register(V view) {
+      views.put(view.unwrap().getName(), view);
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public <V extends View> void unregister(V view) {
+      views.remove(view.unwrap().getName());
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public Iterable<? extends Context> listContexts() {
+      return Iterables.transform(views.values(), new Function<View, Context>() {
+         @Override
+         public Context apply(@Nullable View input) {
+            return input.unwrap();
+         }
+      });
+   }
+
+   /**
+    * {@inheritDoc}
+    */
+   @Override
+   public Context getContext(String name) {
+      return views.get(name).unwrap();
+   }
+
+   private class Key {
+
+      private final String type;
+      private final String name;
+
+      public Key(String type, String name) {
+         this.type = checkNotNull(type, "type");
+         this.name = checkNotNull(name, "name");
+      }
+
+      public Key(ManagedBean mbean, String name) {
+         this(checkNotNull(mbean, "mbean").getType(), name);
+      }
+
+      public String getType() {
+         return type;
+      }
+
+      public String getName() {
+         return name;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if (this == o) return true;
+         if (o == null || getClass() != o.getClass()) return false;
+
+         Key key = (Key) o;
+
+         if (name != null ? !name.equals(key.name) : key.name != null) return false;
+         if (type != null ? !type.equals(key.type) : key.type != null) return false;
+
+         return true;
+      }
+
+      @Override
+      public int hashCode() {
+         int result = type != null ? type.hashCode() : 0;
+         result = 31 * result + (name != null ? name.hashCode() : 0);
+         return result;
+      }
+   }
+}

--- a/jclouds-management/management-core/src/main/java/org/jclouds/management/internal/ManagementUtils.java
+++ b/jclouds-management/management-core/src/main/java/org/jclouds/management/internal/ManagementUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management.internal;
+
+import com.google.common.base.Throwables;
+import org.jclouds.JcloudsVersion;
+
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.OperationsException;
+
+public final class ManagementUtils {
+
+   private static final JcloudsVersion VERSION = JcloudsVersion.get();
+   private static final String OBJECT_NAME_FORMAT = "org.jclouds:type=%s,name=%s,version=%d.%d";
+
+   private ManagementUtils() {
+      //Utility Class
+   }
+
+   /**
+    * Registers a managed object to the mbean server.
+    *
+    * @param mBeanServer
+    * @param mbean
+    * @param type
+    * @param name
+    */
+   public static void register(MBeanServer mBeanServer, Object mbean, String type, String name) {
+      try {
+         ObjectName objectName = objectNameFor(type, name);
+         if (!mBeanServer.isRegistered(objectName)) {
+            mBeanServer.registerMBean(mbean, objectName);
+         }
+      } catch (OperationsException e) {
+         Throwables.propagate(e);
+      } catch (MBeanRegistrationException e) {
+         Throwables.propagate(e);
+      }
+   }
+
+   /**
+    * Un-registers a managed object to the mbean server.
+    *
+    * @param mBeanServer
+    * @param type
+    * @param name
+    */
+   public static void unregister(MBeanServer mBeanServer, String type, String name) {
+      try {
+         ObjectName objectName = objectNameFor(type, name);
+         if (mBeanServer.isRegistered(objectName)) {
+            mBeanServer.unregisterMBean(objectName);
+         }
+      } catch (OperationsException e) {
+         Throwables.propagate(e);
+      } catch (MBeanRegistrationException e) {
+         Throwables.propagate(e);
+      }
+   }
+
+
+   /**
+    * Creates a jclouds {@link javax.management.ObjectName} for the mbean type.
+    *
+    * @param type
+    * @return
+    * @throws javax.management.MalformedObjectNameException
+    */
+   public static ObjectName objectNameFor(String type, String name) throws MalformedObjectNameException {
+      return new ObjectName(String.format(OBJECT_NAME_FORMAT, type, name, VERSION.majorVersion, VERSION.minorVersion));
+   }
+}

--- a/jclouds-management/management-core/src/main/java/org/jclouds/management/osgi/Activator.java
+++ b/jclouds-management/management-core/src/main/java/org/jclouds/management/osgi/Activator.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.management.osgi;
+
+import org.jclouds.management.JcloudsManagement;
+import org.jclouds.management.internal.BaseManagementContext;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+
+import javax.management.MBeanServer;
+
+public class Activator implements BundleActivator {
+
+   private ServiceTracker mbeanServerTracker = null;
+   private ManagementFactoryBundleListener bundleListener = new ManagementFactoryBundleListener();
+   private final JcloudsManagement jcloudsManagement = new JcloudsManagement();
+
+   /**
+    * Called when this bundle is started so the Framework can perform the bundle-specific activities necessary to start
+    * this bundle. This method can be used to register services or to allocate any resources that this bundle needs.
+    * <p/>
+    * <p/>
+    * This method must complete and return to its caller in a timely manner.
+    * 
+    * @param context
+    *           The execution context of the bundle being started.
+    * @throws Exception
+    *            If this method throws an exception, this bundle is marked as stopped and the Framework will remove this
+    *            bundle's listeners, unregister all services registered by this bundle, and release all services used by
+    *            this bundle.
+    */
+   @Override
+   public void start(BundleContext context) throws Exception {
+      bundleListener.start(context);
+      mbeanServerTracker = new ServiceTracker(context, MBeanServer.class.getName(), null) {
+
+         @Override
+         public Object addingService(ServiceReference reference) {
+            Object obj = super.addingService(reference);
+            if (MBeanServer.class.isAssignableFrom(obj.getClass())) {
+               BaseManagementContext.INSTANCE.bind((MBeanServer) obj);
+               BaseManagementContext.INSTANCE.manage(jcloudsManagement, "core");
+            }
+            return obj;
+         }
+
+         @Override
+         public void modifiedService(ServiceReference reference, Object service) {
+            super.modifiedService(reference, service);
+         }
+
+         @Override
+         public void removedService(ServiceReference reference, Object service) {
+            if (MBeanServer.class.isAssignableFrom(service.getClass())) {
+               BaseManagementContext.INSTANCE.unbind((MBeanServer) service);
+            }
+            super.removedService(reference, service);
+         }
+      };
+      mbeanServerTracker.open();
+   }
+
+   /**
+    * Called when this bundle is stopped so the Framework can perform the bundle-specific activities necessary to stop
+    * the bundle. In general, this method should undo the work that the <code>BundleActivator.start</code> method
+    * started. There should be no active threads that were started by this bundle when this bundle returns. A stopped
+    * bundle must not call any Framework objects.
+    * <p/>
+    * <p/>
+    * This method must complete and return to its caller in a timely manner.
+    * 
+    * @param context
+    *           The execution context of the bundle being stopped.
+    * @throws Exception
+    *            If this method throws an exception, the bundle is still marked as stopped, and the Framework will
+    *            remove the bundle's listeners, unregister all services registered by the bundle, and release all
+    *            services used by the bundle.
+    */
+   @Override
+   public void stop(BundleContext context) throws Exception {
+      bundleListener.stop(context);
+      if (mbeanServerTracker != null) {
+         mbeanServerTracker.close();
+      }
+   }
+}

--- a/jclouds-management/management-core/src/main/java/org/jclouds/management/osgi/ManagementFactoryBundleListener.java
+++ b/jclouds-management/management-core/src/main/java/org/jclouds/management/osgi/ManagementFactoryBundleListener.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.management.osgi;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import org.jclouds.management.ViewMBeanFactory;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.BundleListener;
+
+import static org.jclouds.osgi.Bundles.instantiateAvailableClasses;
+import static org.jclouds.osgi.Bundles.stringsForResourceInBundle;
+import static org.osgi.framework.BundleEvent.STARTED;
+import static org.osgi.framework.BundleEvent.STOPPING;
+import static org.osgi.framework.BundleEvent.STOPPED;
+
+/**
+ * A {@link org.osgi.framework.BundleListener} that listens for {@link org.osgi.framework.BundleEvent} and searches for
+ * {@link org.jclouds.providers.ProviderMetadata} and {@link org.jclouds.apis.ApiMetadata} in newly installed Bundles.
+ * This is used as a workaround for OSGi environments where the ServiceLoader cannot cross bundle boundaries.
+ *
+ * @author iocanel
+ */
+public class ManagementFactoryBundleListener implements BundleListener {
+
+   private final Multimap<Long, ViewMBeanFactory> managedViewFactoryMap = ArrayListMultimap.create();
+
+   /**
+    * Starts the listener. Checks the bundles that are already active and registers {@link org.jclouds.providers.ProviderMetadata} and
+    * {@link org.jclouds.apis.ApiMetadata} found. Registers the itself as a {@link org.osgi.framework.BundleListener}.
+    *
+    * @param bundleContext
+    */
+   public synchronized void start(BundleContext bundleContext) {
+      bundleContext.addBundleListener(this);
+      for (Bundle bundle : bundleContext.getBundles()) {
+         if (bundle.getState() == Bundle.ACTIVE) {
+            addBundle(bundle);
+         }
+      }
+      bundleContext.addBundleListener(this);
+   }
+
+   /**
+    * Stops the listener. Removes itself from the {@link org.osgi.framework.BundleListener}s. Clears metadata maps and listeners lists.
+    *
+    * @param bundleContext
+    */
+   public void stop(BundleContext bundleContext) {
+      bundleContext.removeBundleListener(this);
+      managedViewFactoryMap.clear();
+   }
+
+   @Override
+   public synchronized void bundleChanged(BundleEvent event) {
+      switch (event.getType()) {
+      case STARTED:
+         addBundle(event.getBundle());
+         break;
+      case STOPPING:
+      case STOPPED:
+         removeBundle(event.getBundle());
+         break;
+      }
+   }
+
+   /**
+    * Searches for {@link org.jclouds.providers.ProviderMetadata} and {@link org.jclouds.apis.ApiMetadata} inside the {@link org.osgi.framework.Bundle}. If metadata are found
+    * they are registered in the {@link org.jclouds.osgi.ProviderRegistry} and {@link org.jclouds.osgi.ApiRegistry}. Also the {@link org.jclouds.osgi.ProviderListener} and
+    * {@link org.jclouds.osgi.ApiListener} are notified.
+    *
+    * @param bundle
+    */
+   private synchronized void addBundle(Bundle bundle) {
+      for (ViewMBeanFactory viewMBeanFactory : listManagedViewFactories(bundle)) {
+         if (viewMBeanFactory != null) {
+            ViewManagementFactoryRegistry.registerFactory(viewMBeanFactory);
+            managedViewFactoryMap.put(bundle.getBundleId(), viewMBeanFactory);
+         }
+      }
+   }
+
+   /**
+    * Searches for {@link org.jclouds.providers.ProviderMetadata} and {@link org.jclouds.apis.ApiMetadata} registered under the {@link org.osgi.framework.Bundle} id. If metadata
+    * are found they are removed the {@link org.jclouds.osgi.ProviderRegistry} and {@link org.jclouds.osgi.ApiRegistry}. Also the {@link org.jclouds.osgi.ProviderListener}
+    * and {@link org.jclouds.osgi.ApiListener} are notified.
+    *
+    * @param bundle
+    */
+   private synchronized void removeBundle(Bundle bundle) {
+      for (ViewMBeanFactory viewMBeanFactory : managedViewFactoryMap.removeAll(bundle.getBundleId())) {
+            ViewManagementFactoryRegistry.registerFactory(viewMBeanFactory);
+      }
+
+   }
+
+   /**
+    * Creates an instance of {@link org.jclouds.management.ViewMBeanFactory} from the {@link org.osgi.framework.Bundle}.
+    *
+    * @param bundle
+    * @return
+    */
+   public Iterable<ViewMBeanFactory> listManagedViewFactories(Bundle bundle) {
+      Iterable<String> classNames = stringsForResourceInBundle("/META-INF/services/" + ViewMBeanFactory.class.getName(), bundle);
+      return instantiateAvailableClasses(bundle, classNames, ViewMBeanFactory.class);
+   }
+}

--- a/jclouds-management/management-core/src/main/java/org/jclouds/management/osgi/ViewManagementFactoryRegistry.java
+++ b/jclouds-management/management-core/src/main/java/org/jclouds/management/osgi/ViewManagementFactoryRegistry.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management.osgi;
+
+import com.google.common.collect.Sets;
+import org.jclouds.management.ViewMBeanFactory;
+
+import java.util.Set;
+
+public class ViewManagementFactoryRegistry {
+
+   private static final Set<ViewMBeanFactory> factories = Sets.newHashSet();
+
+   public static void registerFactory(ViewMBeanFactory factory) {
+      factories.add(factory);
+   }
+
+   public static void unRegisterFactory(ViewMBeanFactory factory) {
+      factories.remove(factory);
+   }
+
+   public static Iterable<ViewMBeanFactory> fromRegistry() {
+      return factories;
+   }
+
+   public static void clear() {
+      factories.clear();
+   }
+}

--- a/jclouds-management/management-core/src/test/java/org/jclouds/management/ComputeMBeanFactory.java
+++ b/jclouds-management/management-core/src/test/java/org/jclouds/management/ComputeMBeanFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management;
+
+import com.google.common.reflect.TypeToken;
+import org.jclouds.apis.Compute;
+
+public class ComputeMBeanFactory implements ViewMBeanFactory<Compute> {
+
+   /**
+    * Creates a {@link ManagedBean} for the Context.
+    *
+    * @param view
+    * @return
+    */
+   @Override
+   public ViewMBean<Compute> create(Compute view) {
+      return new ComputeManagement();
+   }
+
+   /**
+    * Returns the {@link com.google.common.reflect.TypeToken} of the {@link org.jclouds.View}.
+    *
+    * @return
+    */
+   @Override
+   public TypeToken getViewType() {
+      return TypeToken.of(Compute.class);
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+         return false;
+      }
+      return true;
+   }
+}

--- a/jclouds-management/management-core/src/test/java/org/jclouds/management/ComputeManagement.java
+++ b/jclouds-management/management-core/src/test/java/org/jclouds/management/ComputeManagement.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management;
+
+
+import org.jclouds.apis.Compute;
+
+public class ComputeManagement implements ComputeManagementMBean, ViewMBean<Compute> {
+
+
+   /**
+    * Returns the type of the MBean.
+    *
+    * @return
+    */
+   @Override
+   public String getType() {
+      return "test";
+   }
+}

--- a/jclouds-management/management-core/src/test/java/org/jclouds/management/ComputeManagementMBean.java
+++ b/jclouds-management/management-core/src/test/java/org/jclouds/management/ComputeManagementMBean.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management;
+
+public interface ComputeManagementMBean {
+}

--- a/jclouds-management/management-core/src/test/java/org/jclouds/management/StorageMBeanFactory.java
+++ b/jclouds-management/management-core/src/test/java/org/jclouds/management/StorageMBeanFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management;
+
+import com.google.common.reflect.TypeToken;
+import org.jclouds.apis.Storage;
+
+public class StorageMBeanFactory implements ViewMBeanFactory<Storage> {
+
+   /**
+    * Creates a {@link org.jclouds.management.ManagedBean} for the Context.
+    *
+    * @param view
+    * @return
+    */
+   @Override
+   public ViewMBean<Storage> create(Storage view) {
+      return new StorageManagement();
+   }
+
+   /**
+    * Returns the {@link com.google.common.reflect.TypeToken} of the {@link org.jclouds.View}.
+    *
+    * @return
+    */
+   @Override
+   public TypeToken getViewType() {
+      return TypeToken.of(Storage.class);
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+         return false;
+      }
+      return true;
+   }
+}

--- a/jclouds-management/management-core/src/test/java/org/jclouds/management/StorageManagement.java
+++ b/jclouds-management/management-core/src/test/java/org/jclouds/management/StorageManagement.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management;
+
+import org.jclouds.apis.Storage;
+
+public class StorageManagement implements StorageManagementMBean, ViewMBean<Storage> {
+
+
+   /**
+    * Returns the type of the MBean.
+    *
+    * @return
+    */
+   @Override
+   public String getType() {
+      return "test";
+   }
+}

--- a/jclouds-management/management-core/src/test/java/org/jclouds/management/StorageManagementMBean.java
+++ b/jclouds-management/management-core/src/test/java/org/jclouds/management/StorageManagementMBean.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management;
+
+public interface StorageManagementMBean {
+}

--- a/jclouds-management/management-core/src/test/java/org/jclouds/management/ViewMBeanFactoriesTest.java
+++ b/jclouds-management/management-core/src/test/java/org/jclouds/management/ViewMBeanFactoriesTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management;
+
+import com.google.common.reflect.TypeToken;
+import org.jclouds.apis.Compute;
+import org.jclouds.apis.Storage;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test(groups = "unit", testName = "ViewManagementFactoriesTest")
+public class ViewMBeanFactoriesTest {
+
+   private final ViewMBeanFactory storageFactory = new StorageMBeanFactory();
+   private final ViewMBeanFactory computeTestFactory = new ComputeMBeanFactory();
+
+   @Test
+   void testAll() {
+      Iterable<ViewMBeanFactory> factories = ViewMBeanFactories.all();
+      assertTrue(contains(factories, storageFactory));
+      assertTrue(contains(factories, computeTestFactory));
+   }
+
+   @Test
+   void testManagesView() {
+      Iterable<ViewMBeanFactory> storageFactories = ViewMBeanFactories.forType(TypeToken.of(Storage.class));
+      Iterable<ViewMBeanFactory> otherTestViewfactories = ViewMBeanFactories.forType(TypeToken.of(Compute.class));
+
+      assertTrue(contains(storageFactories, storageFactory));
+      assertFalse(contains(storageFactories, computeTestFactory));
+
+      assertFalse(contains(otherTestViewfactories, storageFactory));
+      assertTrue(contains(otherTestViewfactories, computeTestFactory));
+   }
+
+
+   private static boolean contains(Iterable<ViewMBeanFactory> factories, ViewMBeanFactory f) {
+      for (ViewMBeanFactory factory : factories) {
+         if (f.equals(factory)) {
+            return true;
+         }
+      }
+      return false;
+   }
+}

--- a/jclouds-management/management-core/src/test/java/org/jclouds/management/config/ManagementLifecycleTest.java
+++ b/jclouds-management/management-core/src/test/java/org/jclouds/management/config/ManagementLifecycleTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management.config;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
+import org.jclouds.ContextBuilder;
+import org.jclouds.apis.Compute;
+import org.jclouds.management.ComputeManagement;
+import org.jclouds.management.ManagementContext;
+import org.jclouds.management.internal.BaseManagementContext;
+import org.jclouds.providers.JcloudsTestComputeProviderMetadata;
+import org.testng.annotations.Test;
+
+import static org.easymock.EasyMock.*;
+
+@Test(groups = "unit", testName = "ManagementLifecycleTest")
+public class ManagementLifecycleTest {
+
+
+   @Test
+   void testManagementLifecycle()  {
+      //Test that the ManagementLifeCycle module properly listens for view creation events and context destruction.
+      ManagementContext managementContext = createMock(ManagementContext.class);
+
+      managementContext.register(anyObject(Compute.class));
+      expectLastCall().once();
+      managementContext.manage(anyObject(ComputeManagement.class), eq("testname"));
+      expectLastCall().once();
+      managementContext.unmanage(anyObject(ComputeManagement.class), eq("testname"));
+      expectLastCall().once();
+      managementContext.unregister(anyObject(Compute.class));
+      expectLastCall().once();
+      replay(managementContext);
+
+      Compute compute = ContextBuilder.newBuilder(new JcloudsTestComputeProviderMetadata()).name("testname")
+              .credentials("user", "password")
+              .modules(ImmutableSet.<Module>builder().add(new ManagementLifecycle(managementContext)).build()).build(Compute.class);
+      compute.unwrap().close();
+      verify(managementContext);
+   }
+
+}

--- a/jclouds-management/management-core/src/test/java/org/jclouds/management/internal/ManagementUtilsTest.java
+++ b/jclouds-management/management-core/src/test/java/org/jclouds/management/internal/ManagementUtilsTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.management.internal;
+
+
+import org.testng.annotations.Test;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+
+import static org.easymock.EasyMock.*;
+
+
+@Test(groups = "unit", testName = "ManagementUtilsTest")
+public class ManagementUtilsTest {
+
+   @Test
+   public void testRegister() throws Exception {
+      MBeanServer mBeanServer = createMock(MBeanServer.class);
+
+      ObjectName firstObjectName = ManagementUtils.objectNameFor("test", "first");
+      ObjectName secondObjectName = ManagementUtils.objectNameFor("test", "second");
+      ObjectInstance firstInstance = new ObjectInstance(firstObjectName, "FirstClass");
+      ObjectInstance secondInstance = new ObjectInstance(firstObjectName, "FirstClass");
+
+      expect(mBeanServer.isRegistered(firstObjectName)).andReturn(false).once();
+      expect(mBeanServer.isRegistered(firstObjectName)).andReturn(true).atLeastOnce();
+      expect(mBeanServer.isRegistered(secondObjectName)).andReturn(false).once();
+      expect(mBeanServer.isRegistered(secondObjectName)).andReturn(true).atLeastOnce();
+
+      expect(mBeanServer.registerMBean(anyObject(), eq(firstObjectName))).andReturn(firstInstance).once();
+      expect(mBeanServer.registerMBean(anyObject(), eq(secondObjectName))).andReturn(secondInstance).once();
+      replay(mBeanServer);
+
+      for (int i = 0; i < 5; i++) {
+         ManagementUtils.register(mBeanServer, new Object(), "test", "first");
+      }
+
+      for (int i = 0; i < 5; i++) {
+         ManagementUtils.register(mBeanServer, new Object(), "test", "second");
+      }
+      verify(mBeanServer);
+   }
+
+   @Test
+   public void testUnregister() throws Exception {
+      MBeanServer mBeanServer = createMock(MBeanServer.class);
+
+      ObjectName firstObjectName = ManagementUtils.objectNameFor("test", "first");
+      ObjectName secondObjectName = ManagementUtils.objectNameFor("test", "second");
+
+      expect(mBeanServer.isRegistered(firstObjectName)).andReturn(true).once();
+      expect(mBeanServer.isRegistered(firstObjectName)).andReturn(false).atLeastOnce();
+      expect(mBeanServer.isRegistered(secondObjectName)).andReturn(true).once();
+      expect(mBeanServer.isRegistered(secondObjectName)).andReturn(false).atLeastOnce();
+
+
+      mBeanServer.unregisterMBean(firstObjectName);
+      expectLastCall().once();
+      mBeanServer.unregisterMBean(secondObjectName);
+      expectLastCall().once();
+      replay(mBeanServer);
+
+      for (int i = 0; i < 5; i++) {
+         ManagementUtils.unregister(mBeanServer, "test", "first");
+      }
+
+      for (int i = 0; i < 5; i++) {
+         ManagementUtils.unregister(mBeanServer, "test", "second");
+      }
+      verify(mBeanServer);
+   }
+}

--- a/jclouds-management/management-core/src/test/resources/META-INF/services/org.jclouds.management.ViewMBeanFactory
+++ b/jclouds-management/management-core/src/test/resources/META-INF/services/org.jclouds.management.ViewMBeanFactory
@@ -1,0 +1,2 @@
+org.jclouds.management.StorageMBeanFactory
+org.jclouds.management.ComputeMBeanFactory

--- a/jclouds-management/pom.xml
+++ b/jclouds-management/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to jclouds, Inc. (jclouds) under one or more
+   contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  jclouds licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>jclouds-labs</artifactId>
+        <groupId>org.jclouds.labs</groupId>
+        <version>1.7.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jclouds.labs</groupId>
+    <artifactId>jclouds-management</artifactId>
+    <packaging>pom</packaging>
+    <name>jclouds :: management</name>
+
+    <modules>
+        <module>management-core</module>
+        <module>management-compute</module>
+        <module>management-blobstore</module>
+    </modules>
+
+
+</project>

--- a/jclouds-representations/README.md
+++ b/jclouds-representations/README.md
@@ -1,0 +1,27 @@
+jclouds representations
+=======================
+
+This project provides representations for the jclouds domain objects.
+The representation object have no dependency in the acutal jclouds modules and can be used as a "thin client" from
+other software that wants to integrate with jclouds.
+
+The original intention was to be used for JMX integration but can also be used for REST etc.
+
+The project contains two submodules:
+
+* representations-core
+* represtations-codec
+
+representations-core
+--------------------
+
+Contains representation objects for core, compute & blobstore modules of jclouds.
+
+
+representations-codec
+---------------------
+
+Contains convertion functions for the actual jclouds domain objects to their representations.
+It also includes a ComputeService and BlobStore interface which use the representation instead of the domain objects.
+
+**Note:** This module does depend from jclouds.

--- a/jclouds-representations/pom.xml
+++ b/jclouds-representations/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>jclouds-labs</artifactId>
+        <groupId>org.jclouds.labs</groupId>
+        <version>1.7.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jclouds.labs</groupId>
+    <artifactId>jclouds-represetations</artifactId>
+    <packaging>pom</packaging>
+    <name>jclouds :: represetations</name>
+    <description>Representations objects for jclouds domain objects</description>
+
+    <modules>
+        <module>representations-core</module>
+        <module>representations-codec</module>
+    </modules>
+
+</project>

--- a/jclouds-representations/representations-codec/pom.xml
+++ b/jclouds-representations/representations-codec/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.jclouds.labs</groupId>
+        <artifactId>jclouds-represetations</artifactId>
+        <version>1.7.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jclouds.labs.representations</groupId>
+    <artifactId>representations-codec</artifactId>
+    <packaging>bundle</packaging>
+    <name>jclouds :: representations :: codec</name>
+
+    <properties>
+        <jclouds.osgi.import>
+            org.jclouds.blobstore*;version="${project.version}";resolution:=optional,
+            org.jclouds.compute*;version="${project.version}";resolution:=optional,
+            *
+        </jclouds.osgi.import>
+        <jclouds.osgi.export>
+            org.jclouds.codec*;version=${project.version};-noimport:=true,
+            org.jclouds.compute.codec*;version=${project.version};-noimport:=true,
+            org.jclouds.blobstore.codec*;version=${project.version};-noimport:=true
+        </jclouds.osgi.export>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jclouds.labs.representations</groupId>
+            <artifactId>representations-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jclouds</groupId>
+            <artifactId>jclouds-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jclouds</groupId>
+            <artifactId>jclouds-compute</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jclouds</groupId>
+            <artifactId>jclouds-blobstore</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>14.0.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jclouds</groupId>
+            <artifactId>jclouds-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/jclouds-representations/representations-codec/src/main/java/org/jclouds/blobstore/codec/ToBlob.java
+++ b/jclouds-representations/representations-codec/src/main/java/org/jclouds/blobstore/codec/ToBlob.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.blobstore.codec;
+
+import com.google.common.base.Function;
+import org.jclouds.blobstore.representations.Blob;
+import org.jclouds.javax.annotation.Nullable;
+
+
+public enum ToBlob implements Function<org.jclouds.blobstore.domain.Blob, Blob> {
+
+   INSTANCE;
+
+   @Override
+   public Blob apply(@Nullable org.jclouds.blobstore.domain.Blob input) {
+      if (input == null) {
+         return null;
+      }
+      return Blob.builder().allHeaders(input.getAllHeaders().asMap())
+                 .blobMetadata(ToBlobMetadata.INSTANCE.apply(input.getMetadata())).build();
+   }
+
+
+}

--- a/jclouds-representations/representations-codec/src/main/java/org/jclouds/blobstore/codec/ToBlobMetadata.java
+++ b/jclouds-representations/representations-codec/src/main/java/org/jclouds/blobstore/codec/ToBlobMetadata.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.blobstore.codec;
+
+import com.google.common.base.Function;
+import org.jclouds.blobstore.representations.BlobMetadata;
+import org.jclouds.javax.annotation.Nullable;
+
+public enum ToBlobMetadata implements Function<org.jclouds.blobstore.domain.BlobMetadata, BlobMetadata> {
+
+   INSTANCE;
+
+   @Override
+   public BlobMetadata apply(@Nullable org.jclouds.blobstore.domain.BlobMetadata input) {
+      if (input == null) {
+         return null;
+      }
+      return BlobMetadata.builder()
+                         .publicUri(input.getPublicUri()).type(input.getType().name()).providerId(input.getProviderId())
+                         .name(input.getName()).uri(input.getUri()).userMetadata(input.getUserMetadata())
+                         .eTag(input.getETag()).creationDate(input.getCreationDate()).lastModifiedDate(input.getLastModified())
+                         .content(ToContentContentMetadata.INSTANCE.apply(input.getContentMetadata()))
+                         .build();
+   }
+}

--- a/jclouds-representations/representations-codec/src/main/java/org/jclouds/blobstore/codec/ToContentContentMetadata.java
+++ b/jclouds-representations/representations-codec/src/main/java/org/jclouds/blobstore/codec/ToContentContentMetadata.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.blobstore.codec;
+
+import com.google.common.base.Function;
+import org.jclouds.blobstore.representations.ContentMetadata;
+import org.jclouds.javax.annotation.Nullable;
+
+public enum ToContentContentMetadata implements Function<org.jclouds.io.ContentMetadata, ContentMetadata> {
+
+   INSTANCE;
+
+   @Override
+   public ContentMetadata apply(@Nullable org.jclouds.io.ContentMetadata input) {
+      if (input == null) {
+         return null;
+      }
+      return ContentMetadata.builder().type(input.getContentType()).disposition(input.getContentDisposition())
+                            .encoding(input.getContentEncoding()).length(input.getContentLength())
+                            .expires(input.getExpires())
+                            .build();
+   }
+}

--- a/jclouds-representations/representations-codec/src/main/java/org/jclouds/blobstore/codec/ToStorageMetadata.java
+++ b/jclouds-representations/representations-codec/src/main/java/org/jclouds/blobstore/codec/ToStorageMetadata.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.blobstore.codec;
+
+import com.google.common.base.Function;
+import org.jclouds.blobstore.representations.StorageMetadata;
+import org.jclouds.javax.annotation.Nullable;
+
+public enum ToStorageMetadata implements Function<org.jclouds.blobstore.domain.StorageMetadata, StorageMetadata> {
+
+   INSTANCE;
+
+   @Override
+   public StorageMetadata apply(@Nullable org.jclouds.blobstore.domain.StorageMetadata input) {
+      if (input == null) {
+         return null;
+      }
+      return StorageMetadata.builder().type(input.getType().name()).providerId(input.getProviderId())
+                            .name(input.getName()).uri(input.getUri()).userMetadata(input.getUserMetadata())
+                            .eTag(input.getETag()).creationDate(input.getCreationDate()).lastModifiedDate(input.getLastModified())
+                            .build();
+   }
+}

--- a/jclouds-representations/representations-codec/src/main/java/org/jclouds/codec/ToApiMetadata.java
+++ b/jclouds-representations/representations-codec/src/main/java/org/jclouds/codec/ToApiMetadata.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.codec;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.TypeToken;
+import com.google.inject.Module;
+import org.jclouds.View;
+import org.jclouds.representations.ApiMetadata;
+import org.jclouds.javax.annotation.Nullable;
+
+import static com.google.common.collect.Iterables.transform;
+
+public enum ToApiMetadata implements Function<org.jclouds.apis.ApiMetadata, ApiMetadata> {
+
+   INSTANCE;
+
+   @Override
+   public ApiMetadata apply(@Nullable org.jclouds.apis.ApiMetadata input) {
+      if (input == null) {
+         return null;
+      }
+      return ApiMetadata.builder().id(input.getId()).name(input.getName()).endpointName(input.getEndpointName())
+                         .identityName(input.getIdentityName()).credentialName(input.getCredentialName().orNull())
+                         .version(input.getVersion())
+                         .defaultEndpoint(input.getDefaultEndpoint().orNull())
+                         .defaultIdentity(input.getDefaultIdentity().orNull())
+                         .defaultCredential(input.getDefaultCredential().orNull())
+                         .defaultProperties(input.getDefaultProperties())
+                         .documentation(input.getDocumentation())
+                         .context(input.getContext().getType().toString())
+
+                         .defaultModules(ImmutableSet.<String>builder().addAll(transform(input.getDefaultModules(), new Function<Class<? extends Module>, String>() {
+                           @Override
+                           public String apply(@Nullable Class<? extends Module> input) {
+                              return input.getName();
+                           }
+                         })).build())
+
+                         .views(ImmutableSet.<String>builder().addAll(transform(input.getViews(), new Function<TypeToken<? extends View>, String>() {
+                           @Override
+                           public String apply(@Nullable TypeToken<? extends View> input) {
+                              return input.getRawType().getName();
+                           }
+                         })).build())
+
+                         .build();
+   }
+}

--- a/jclouds-representations/representations-codec/src/main/java/org/jclouds/codec/ToContext.java
+++ b/jclouds-representations/representations-codec/src/main/java/org/jclouds/codec/ToContext.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.codec;
+
+import com.google.common.base.Function;
+import org.jclouds.representations.Context;
+import org.jclouds.javax.annotation.Nullable;
+
+public enum ToContext implements Function<org.jclouds.Context, Context> {
+
+   INSTANCE;
+
+   @Override
+   public Context apply(@Nullable org.jclouds.Context input) {
+      if (input == null) {
+         return null;
+      }
+      return Context.builder().name(input.getName()).identity(input.getIdentity())
+              .providerId(input.getProviderMetadata() != null ? input.getProviderMetadata().getId() : null).build();
+   }
+}

--- a/jclouds-representations/representations-codec/src/main/java/org/jclouds/codec/ToLocation.java
+++ b/jclouds-representations/representations-codec/src/main/java/org/jclouds/codec/ToLocation.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.codec;
+
+import com.google.common.base.Function;
+import org.jclouds.representations.Location;
+import org.jclouds.javax.annotation.Nullable;
+
+public enum ToLocation implements Function<org.jclouds.domain.Location, Location> {
+
+   INSTANCE;
+
+   @Override
+   public Location apply(@Nullable org.jclouds.domain.Location input) {
+      if (input == null) {
+         return null;
+      }
+      return Location.builder().id(input.getId()).scope(input.getScope().name())
+                     .parentId(input.getParent() != null ? input.getParent().getId() : null)
+                     .description(input.getDescription())
+                     .iso3166Codes(input.getIso3166Codes()).build();
+   }
+}

--- a/jclouds-representations/representations-codec/src/main/java/org/jclouds/codec/ToProvider.java
+++ b/jclouds-representations/representations-codec/src/main/java/org/jclouds/codec/ToProvider.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.codec;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
+import com.google.inject.Module;
+import org.jclouds.View;
+import org.jclouds.representations.ProviderMetadata;
+import org.jclouds.javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.Properties;
+
+import static com.google.common.collect.Iterables.transform;
+
+public enum ToProvider implements Function<org.jclouds.providers.ProviderMetadata, ProviderMetadata> {
+
+   INSTANCE;
+
+   public ProviderMetadata apply(@Nullable org.jclouds.providers.ProviderMetadata input) {
+      if (input == null) {
+         return null;
+      }
+
+
+
+
+      return ProviderMetadata.builder().id(input.getId()).name(input.getName())
+                             .endpoint(input.getEndpoint())
+                             .console(input.getConsole().orNull()).homePage(input.getHomepage().orNull())
+                             .linkedServices(input.getLinkedServices()).iso3166Codes(input.getIso3166Codes())
+                             .identityName(input.getApiMetadata().getIdentityName())
+                             .credentialName(input.getApiMetadata().getCredentialName().orNull())
+                             .endpointName(input.getApiMetadata().getEndpointName())
+                             .documentation(input.getApiMetadata().getDocumentation().toString())
+                             .defaultProperties(fromProperties(input.getApiMetadata().getDefaultProperties(), input.getDefaultProperties()))
+
+                             .defaultModules(ImmutableSet.<String>builder().addAll(transform(input.getApiMetadata().getDefaultModules(), new Function<Class<? extends Module>, String>() {
+                                @Override
+                                public String apply(@Nullable Class<? extends Module> input) {
+                                   return input.getName();
+                                }
+                             })).build())
+
+                             .views(ImmutableSet.<String>builder().addAll(transform(input.getApiMetadata().getViews(), new Function<TypeToken<? extends View>, String>() {
+                                @Override
+                                public String apply(@Nullable TypeToken<? extends View> input) {
+                                   return input.getRawType().getName();
+                                }
+                             })).build())
+
+                             .build();
+   }
+
+   /**
+    * Merges multiple {@link Properties} into a {@link Map}.
+    * In case of duplicate keys, the latest value will be kept.
+    * This utility is mostly needed because the map builder can't handle duplicates.
+    * @param properties
+    * @return
+    */
+   private static Map<String, String> fromProperties(Properties ... properties) {
+      Map<String, String> map = Maps.newHashMap();
+      for (Properties p : properties) {
+         map.putAll(Maps.fromProperties(p));
+      }
+      return map;
+   }
+}

--- a/jclouds-representations/representations-codec/src/main/java/org/jclouds/compute/codec/ToExecResponse.java
+++ b/jclouds-representations/representations-codec/src/main/java/org/jclouds/compute/codec/ToExecResponse.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.codec;
+
+import com.google.common.base.Function;
+import org.jclouds.compute.representations.ExecResponse;
+import org.jclouds.javax.annotation.Nullable;
+
+public enum ToExecResponse implements Function<org.jclouds.compute.domain.ExecResponse, ExecResponse> {
+
+   INSTANCE;
+
+   @Override
+   public ExecResponse apply(@Nullable org.jclouds.compute.domain.ExecResponse input) {
+      if (input == null) {
+         return null;
+      }
+      return ExecResponse.builder().output(input.getOutput()).error(input.getError()).exitStatus(input.getExitStatus())
+              .build();
+   }
+}

--- a/jclouds-representations/representations-codec/src/main/java/org/jclouds/compute/codec/ToHardware.java
+++ b/jclouds-representations/representations-codec/src/main/java/org/jclouds/compute/codec/ToHardware.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.codec;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import org.jclouds.compute.representations.Hardware;
+import org.jclouds.compute.representations.Processor;
+import org.jclouds.compute.representations.Volume;
+import org.jclouds.javax.annotation.Nullable;
+
+import static com.google.common.collect.Iterables.transform;
+
+public enum ToHardware implements Function<org.jclouds.compute.domain.Hardware, Hardware> {
+
+   INSTANCE;
+
+   @Override
+   public Hardware apply(@Nullable org.jclouds.compute.domain.Hardware input) {
+      if (input == null) {
+         return null;
+      }
+      return Hardware.builder().id(input.getId()).name(input.getName()).hypervisor(input.getHypervisor())
+                     .ram(input.getRam())
+                      //Transformation is lazy and doesn't serialize well, so let's wrap the processor list
+                     .processors(ImmutableList.<Processor>builder().addAll(transform(input.getProcessors(), ToProcessor.INSTANCE)).build())
+
+                      //Transformation is lazy and doesn't serialize well, so let's wrap the volume list
+                     .volumes(ImmutableList.<Volume>builder().addAll(transform(input.getVolumes(), ToVolume.INSTANCE)).build())
+                     .build();
+   }
+}

--- a/jclouds-representations/representations-codec/src/main/java/org/jclouds/compute/codec/ToImage.java
+++ b/jclouds-representations/representations-codec/src/main/java/org/jclouds/compute/codec/ToImage.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.codec;
+
+import com.google.common.base.Function;
+import org.jclouds.compute.representations.Image;
+import org.jclouds.javax.annotation.Nullable;
+
+public enum ToImage implements Function<org.jclouds.compute.domain.Image, Image> {
+
+   INSTANCE;
+
+   @Override
+   public Image apply(@Nullable org.jclouds.compute.domain.Image input) {
+      if (input == null) {
+         return null;
+      }
+      return Image.builder().id(input.getId()).name(input.getName()).status(input.getStatus().name())
+                  .tags(input.getTags()).version(input.getVersion()).description(input.getDescription())
+                  .operatingSystem(ToOperatingSystem.INSTANCE.apply(input.getOperatingSystem()))
+                  .defaultCredentials(ToLoginCredentials.INSTANCE.apply(input.getDefaultCredentials())).build();
+
+   }
+}

--- a/jclouds-representations/representations-codec/src/main/java/org/jclouds/compute/codec/ToLoginCredentials.java
+++ b/jclouds-representations/representations-codec/src/main/java/org/jclouds/compute/codec/ToLoginCredentials.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.codec;
+
+import com.google.common.base.Function;
+import org.jclouds.compute.representations.LoginCredentials;
+import org.jclouds.javax.annotation.Nullable;
+
+public enum ToLoginCredentials implements Function<org.jclouds.domain.LoginCredentials, LoginCredentials> {
+
+   INSTANCE;
+
+   @Override
+   public LoginCredentials apply(@Nullable org.jclouds.domain.LoginCredentials input) {
+      if (input == null) {
+         return null;
+      }
+      return LoginCredentials.builder().username(input.getUser()).password(input.getPassword())
+                             .privateKey(input.getPrivateKey()).authenticateSudo(input.shouldAuthenticateSudo())
+                             .build();
+   }
+}

--- a/jclouds-representations/representations-codec/src/main/java/org/jclouds/compute/codec/ToNodeMetadata.java
+++ b/jclouds-representations/representations-codec/src/main/java/org/jclouds/compute/codec/ToNodeMetadata.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.codec;
+
+import com.google.common.base.Function;
+import org.jclouds.compute.representations.NodeMetadata;
+import org.jclouds.javax.annotation.Nullable;
+
+public enum ToNodeMetadata implements Function<org.jclouds.compute.domain.NodeMetadata, NodeMetadata> {
+
+   INSTANCE;
+
+   @Override
+   public NodeMetadata apply(@Nullable org.jclouds.compute.domain.NodeMetadata input) {
+      if (input == null) {
+         return null;
+      }
+      return NodeMetadata.builder().id(input.getId()).name(input.getName()).status(input.getStatus().name())
+                           .hostname(input.getHostname())
+                           .loginPort(input.getLoginPort()).group(input.getGroup())
+                           .tags(input.getTags()).metadata(input.getUserMetadata())
+                           .locationId(input.getLocation() != null ? input.getLocation().getId() : null)
+                           .imageId(input.getImageId())
+                           .defaultCredentials(ToLoginCredentials.INSTANCE.apply(input.getCredentials())).build();
+   }
+}

--- a/jclouds-representations/representations-codec/src/main/java/org/jclouds/compute/codec/ToOperatingSystem.java
+++ b/jclouds-representations/representations-codec/src/main/java/org/jclouds/compute/codec/ToOperatingSystem.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.codec;
+
+import com.google.common.base.Function;
+import org.jclouds.compute.representations.OperatingSystem;
+import org.jclouds.javax.annotation.Nullable;
+
+public enum ToOperatingSystem implements Function<org.jclouds.compute.domain.OperatingSystem, OperatingSystem> {
+
+   INSTANCE;
+
+   @Override
+   public OperatingSystem apply(@Nullable org.jclouds.compute.domain.OperatingSystem input) {
+      if (input == null) {
+         return null;
+      }
+      return OperatingSystem.builder().family(input.getFamily().name()).version(input.getVersion()).name(input.getName())
+                            .arch(input.getArch()).is64Bit(input.is64Bit()).build();
+   }
+}

--- a/jclouds-representations/representations-codec/src/main/java/org/jclouds/compute/codec/ToProcessor.java
+++ b/jclouds-representations/representations-codec/src/main/java/org/jclouds/compute/codec/ToProcessor.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.codec;
+
+import com.google.common.base.Function;
+import org.jclouds.compute.representations.Processor;
+import org.jclouds.javax.annotation.Nullable;
+
+public enum ToProcessor implements Function<org.jclouds.compute.domain.Processor, Processor> {
+
+   INSTANCE;
+
+   @Override
+   public Processor apply(@Nullable org.jclouds.compute.domain.Processor input) {
+      if (input == null) {
+         return null;
+      }
+      return Processor.builder().cores(input.getCores()).speed(input.getSpeed()).build();
+   }
+}

--- a/jclouds-representations/representations-codec/src/main/java/org/jclouds/compute/codec/ToVolume.java
+++ b/jclouds-representations/representations-codec/src/main/java/org/jclouds/compute/codec/ToVolume.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.codec;
+
+import com.google.common.base.Function;
+import org.jclouds.compute.representations.Volume;
+import org.jclouds.javax.annotation.Nullable;
+
+public enum ToVolume implements Function<org.jclouds.compute.domain.Volume, Volume> {
+
+   INSTANCE;
+
+   @Override
+   public Volume apply(@Nullable org.jclouds.compute.domain.Volume input) {
+      if (input == null) {
+         return null;
+      }
+      return Volume.builder().id(input.getId()).size(input.getSize()).type(input.getType().name()).device(input.getDevice())
+                   .durable(input.isDurable()).bootDevice(input.isBootDevice()).build();
+   }
+}

--- a/jclouds-representations/representations-codec/src/test/java/org/jclouds/blobstore/codec/BlobStoreConversionsTest.java
+++ b/jclouds-representations/representations-codec/src/test/java/org/jclouds/blobstore/codec/BlobStoreConversionsTest.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.blobstore.codec;
+
+import com.google.common.collect.ImmutableSet;
+import org.jclouds.ContextBuilder;
+import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.BlobStoreContext;
+import org.jclouds.blobstore.representations.Blob;
+import org.jclouds.blobstore.representations.StorageMetadata;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+import static com.google.common.collect.Iterables.transform;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+@Test
+public class BlobStoreConversionsTest {
+
+   private BlobStore getBlobStore() {
+      BlobStoreContext context = ContextBuilder.newBuilder("transient").name("test-transient").credentials("user", "pass").build(BlobStoreContext.class);
+      return context.getBlobStore();
+   }
+
+   @Test
+   void testToStorageMetadata() {
+      assertNull(ToStorageMetadata.INSTANCE.apply(null));
+      BlobStore blobStore = getBlobStore();
+      blobStore.createContainerInLocation(null, "test");
+      blobStore.createDirectory("test", "one");
+      Set<StorageMetadata> storageMetadataSet = ImmutableSet.<StorageMetadata>builder()
+                                                            .addAll(transform(blobStore.list(), ToStorageMetadata.INSTANCE))
+                                                            .build();
+      assertFalse(storageMetadataSet.isEmpty());
+      StorageMetadata representation = storageMetadataSet.iterator().next();
+      assertEquals("test", representation.getName());
+   }
+
+   @Test
+   void testToBlob() {
+      assertNull(ToBlob.INSTANCE.apply(null));
+      BlobStore blobStore = getBlobStore();
+      blobStore.createContainerInLocation(null, "container");
+      blobStore.createDirectory("container", "one");
+
+      blobStore.putBlob("container", blobStore.blobBuilder("myblob").payload("testcontent").build());
+      Blob representation = ToBlob.INSTANCE.apply(blobStore.getBlob("container", "myblob"));
+      assertNotNull(representation);
+      assertNotNull(representation.getBlobMetadata());
+   }
+}

--- a/jclouds-representations/representations-codec/src/test/java/org/jclouds/codec/ToApiMetadataTest.java
+++ b/jclouds-representations/representations-codec/src/test/java/org/jclouds/codec/ToApiMetadataTest.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.codec;
+
+import com.google.common.collect.ImmutableSet;
+import org.jclouds.apis.Apis;
+import org.jclouds.representations.ApiMetadata;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+import static com.google.common.collect.Iterables.transform;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+@Test
+public class ToApiMetadataTest {
+
+   @Test
+   void testConversion() {
+      assertNull(ToApiMetadata.INSTANCE.apply(null));
+      org.jclouds.apis.ApiMetadata stub = Apis.withId("stub");
+      assertNotNull(stub);
+      ApiMetadata dto = ToApiMetadata.INSTANCE.apply(stub);
+      assertNotNull(dto);
+      assertEquals("stub", dto.getId());
+   }
+
+   @Test
+   void testIterableTransformation() {
+      Set<ApiMetadata> representations = ImmutableSet.<ApiMetadata>builder()
+                                          .addAll(transform(Apis.all(), ToApiMetadata.INSTANCE))
+                                          .build();
+      assertFalse(representations.isEmpty());
+   }
+}

--- a/jclouds-representations/representations-codec/src/test/java/org/jclouds/codec/ToContextTest.java
+++ b/jclouds-representations/representations-codec/src/test/java/org/jclouds/codec/ToContextTest.java
@@ -1,0 +1,22 @@
+package org.jclouds.codec;
+
+import org.jclouds.ContextBuilder;
+import org.jclouds.representations.Context;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+@Test
+public class ToContextTest {
+
+   @Test
+   void testConversion() {
+      assertNull(ToContext.INSTANCE.apply(null));
+      org.jclouds.Context context = ContextBuilder.newBuilder("stub").name("test-stub").credentials("user", "pass").build();
+      Context representation = ToContext.INSTANCE.apply(context);
+      assertNotNull(representation);
+      assertEquals("test-stub", representation.getName());
+   }
+}

--- a/jclouds-representations/representations-codec/src/test/java/org/jclouds/compute/codec/ComputeConversionsTest.java
+++ b/jclouds-representations/representations-codec/src/test/java/org/jclouds/compute/codec/ComputeConversionsTest.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.compute.codec;
+
+import com.google.common.collect.ImmutableSet;
+import org.jclouds.ContextBuilder;
+import org.jclouds.codec.ToLocation;
+import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.ComputeServiceContext;
+import org.jclouds.compute.representations.Hardware;
+import org.jclouds.compute.representations.Image;
+import org.jclouds.representations.Location;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+import static com.google.common.collect.Iterables.transform;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+@Test
+public class ComputeConversionsTest {
+
+   private ComputeService getCompute() {
+      ComputeServiceContext context = ContextBuilder.newBuilder("stub").name("test-stub").credentials("user", "pass").build(ComputeServiceContext.class);
+      return context.getComputeService();
+   }
+
+   @Test
+   void testToHardware() {
+      assertNull(ToHardware.INSTANCE.apply(null));
+      ComputeService compute = getCompute();
+      Set<Hardware> hardwareSet = ImmutableSet.<Hardware>builder()
+                                              .addAll(transform(compute.listHardwareProfiles(), ToHardware.INSTANCE))
+                                              .build();
+      assertFalse(hardwareSet.isEmpty());
+      for (Hardware representation : hardwareSet) {
+         assertTrue(representation.getRam() > 0);
+      }
+   }
+
+   @Test
+   void testToImage() {
+      assertNull(ToImage.INSTANCE.apply(null));
+      ComputeService compute = getCompute();
+      Set<Image> imageSet = ImmutableSet.<Image>builder()
+                                        .addAll(transform(compute.listImages(), ToImage.INSTANCE))
+                                        .build();
+
+      assertFalse(imageSet.isEmpty());
+      for (Image representation : imageSet) {
+         assertNotNull(representation.getId());
+         assertNotNull(representation.getOperatingSystem());
+      }
+   }
+
+   @Test
+   void testToLocation() {
+      assertNull(ToLocation.INSTANCE.apply(null));
+      ComputeService compute = getCompute();
+      Set<Location> locationSet = ImmutableSet.<Location>builder()
+                                              .addAll(transform(compute.listAssignableLocations(), ToLocation.INSTANCE))
+                                              .build();
+      assertFalse(locationSet.isEmpty());
+
+      for (Location representation : locationSet) {
+         assertNotNull(representation.getId());
+         assertNotNull(representation.getScope());
+      }
+   }
+}

--- a/jclouds-representations/representations-core/pom.xml
+++ b/jclouds-representations/representations-core/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Licensed to jclouds, Inc. (jclouds) under one or more
+contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  jclouds licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.jclouds.labs</groupId>
+        <artifactId>jclouds-represetations</artifactId>
+        <version>1.7.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jclouds.labs.representations</groupId>
+    <artifactId>representations-core</artifactId>
+    <name>jclouds :: representations :: core</name>
+    <packaging>bundle</packaging>
+
+    <properties>
+        <jclouds.osgi.import>*</jclouds.osgi.import>
+        <jclouds.osgi.export>
+            org.jclouds*;version=${project.version};-noimport:=true
+        </jclouds.osgi.export>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>14.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.2.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jclouds</groupId>
+            <artifactId>jclouds-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/blobstore/representations/Blob.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/blobstore/representations/Blob.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.blobstore.representations;
+
+import com.google.common.base.Objects;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Map;
+
+public class Blob implements Serializable {
+
+   private static final long serialVersionUID = 6035812193926955340L;
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private Map<String, Collection<String>> allHeaders;
+      private BlobMetadata blobMetadata;
+
+      public Builder allHeaders(final Map<String, Collection<String>> allHeaders) {
+         this.allHeaders = allHeaders;
+         return this;
+      }
+
+      public Builder blobMetadata(final BlobMetadata blobMetadata) {
+         this.blobMetadata = blobMetadata;
+         return this;
+      }
+
+      public Blob build() {
+         return new Blob(allHeaders, blobMetadata);
+      }
+   }
+
+   private final Map<String, Collection<String>> allHeaders;
+   private final BlobMetadata blobMetadata;
+
+   public Blob(Map<String, Collection<String>> allHeaders, BlobMetadata blobMetadata) {
+      this.allHeaders = allHeaders;
+      this.blobMetadata = blobMetadata;
+   }
+
+   public Map<String, Collection<String>> getAllHeaders() {
+      return allHeaders;
+   }
+
+   public BlobMetadata getBlobMetadata() {
+      return blobMetadata;
+   }
+
+   public int hashCode() {
+      return Objects.hashCode(blobMetadata, allHeaders);
+   }
+
+   @Override
+   public boolean equals(Object that) {
+      if (that == null)
+         return false;
+      return Objects.equal(this.toString(), that.toString());
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this).add("blobMetadata", blobMetadata).add("allHeaders", allHeaders)
+              .toString();
+   }
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/blobstore/representations/BlobMetadata.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/blobstore/representations/BlobMetadata.java
@@ -1,0 +1,218 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.blobstore.representations;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.Date;
+import java.util.Map;
+
+import static org.jclouds.representations.Representations.dateFormat;
+
+public class BlobMetadata implements Serializable {
+
+   private static final long serialVersionUID = 1348620321325703530L;
+
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private String publicUri;
+      private ContentMetadata content;
+      private String type;
+      private String providerId;
+      private String name;
+      private String uri;
+      private Map<String, String> userMetadata = ImmutableMap.of();
+      private String eTag;
+      private String creationDate;
+      private String lastModifiedDate;
+
+      public Builder type(final String type) {
+         this.type = type;
+         return this;
+      }
+
+      public Builder providerId(final String providerId) {
+         this.providerId = providerId;
+         return this;
+      }
+
+      public Builder name(final String name) {
+         this.name = name;
+         return this;
+      }
+
+      public Builder uri(final URI uri) {
+         if (uri != null) {
+            this.uri = uri.toString();
+         }
+         return this;
+      }
+
+      public Builder uri(final String uri) {
+         this.uri = uri;
+         return this;
+      }
+
+      public Builder userMetadata(final Map<String, String> userMetadata) {
+         this.userMetadata = ImmutableMap.copyOf(userMetadata);
+         return this;
+      }
+
+      public Builder eTag(final String eTag) {
+         this.eTag = eTag;
+         return this;
+      }
+
+      public Builder creationDate(final Date creationDate) {
+         this.creationDate = dateFormat(creationDate);
+         return this;
+      }
+
+      public Builder creationDate(final String creationDate) {
+         this.creationDate = creationDate;
+         return this;
+      }
+
+      public Builder lastModifiedDate(final Date lastModifiedDate) {
+         this.lastModifiedDate = dateFormat(lastModifiedDate);
+         return this;
+      }
+
+      public Builder lastModifiedDate(final String lastModifiedDate) {
+         this.lastModifiedDate = lastModifiedDate;
+         return this;
+      }
+
+      public Builder publicUri(final URI publicUri) {
+         if (publicUri != null) {
+            this.publicUri = publicUri.toString();
+         }
+         return this;
+      }
+
+      public Builder publicUri(final String publicUri) {
+         this.publicUri = publicUri;
+         return this;
+      }
+
+      public Builder content(final ContentMetadata content) {
+         this.content = content;
+         return this;
+      }
+
+      public BlobMetadata build() {
+         return new BlobMetadata(type, providerId, name, uri, userMetadata, eTag, creationDate, lastModifiedDate,
+                 publicUri, content);
+      }
+   }
+
+   private final String type;
+   private final String providerId;
+   private final String name;
+   private final String uri;
+   private final Map<String, String> userMetadata;
+   private final String eTag;
+   private final String creationDate;
+   private final String lastModifiedDate;
+   private final String publicUri;
+   private final ContentMetadata contentMetadata;
+
+   public BlobMetadata(String type, String providerId, String name, String uri, Map<String, String> userMetadata,
+                       String eTag, String creationDate, String lastModifiedDate, String publicUri,
+                       ContentMetadata contentMetadata) {
+      this.type = type;
+      this.providerId = providerId;
+      this.name = name;
+      this.uri = uri;
+      this.userMetadata = userMetadata;
+      this.eTag = eTag;
+      this.creationDate = creationDate;
+      this.lastModifiedDate = lastModifiedDate;
+      this.publicUri = publicUri;
+      this.contentMetadata = contentMetadata;
+   }
+
+   public String getPublicUri() {
+      return publicUri;
+   }
+
+   public ContentMetadata getContentMetadata() {
+      return contentMetadata;
+   }
+
+
+   public String getType() {
+      return type;
+   }
+
+   public String getProviderId() {
+      return providerId;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public String getUri() {
+      return uri;
+   }
+
+   public Map<String, String> getUserMetadata() {
+      return userMetadata;
+   }
+
+   public String geteTag() {
+      return eTag;
+   }
+
+   public String getCreationDate() {
+      return creationDate;
+   }
+
+   public String getLastModifiedDate() {
+      return lastModifiedDate;
+   }
+
+   public int hashCode() {
+      return Objects.hashCode(publicUri);
+   }
+
+   @Override
+   public boolean equals(Object that) {
+      if (that == null)
+         return false;
+      return Objects.equal(this.toString(), that.toString());
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this).add("type", type).add("providerId", providerId).add("name", name)
+              .add("userMetadata", userMetadata).add("eTag", eTag).add("creationDate", creationDate)
+              .add("lastModifiedDate", lastModifiedDate).add("publicUri", publicUri).add("contentMetadata", contentMetadata)
+              .toString();
+   }
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/blobstore/representations/BlobStore.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/blobstore/representations/BlobStore.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.blobstore.representations;
+
+import org.jclouds.representations.Location;
+
+import java.util.Set;
+
+public interface BlobStore {
+
+   /**
+    * The get locations command returns all the valid locations for containers. A location has a
+    * scope, which is typically region or zone. A region is a general area, like eu-west, where a
+    * zone is similar to a datacenter. If a location has a parent, that implies it is within that
+    * location. For example a location can be a rack, whose parent is likely to be a zone.
+    */
+   Set<Location> listAssignableLocations();
+
+   /**
+    * Lists all root-level resources available to the identity.
+    */
+   Set<StorageMetadata> list();
+
+   /**
+    * Lists all resources in a container non-recursive.
+    *
+    * @param container
+    *           what to list
+    * @return a list that may be incomplete, depending on whether PageSet#getNextMarker is set
+    */
+   Set<StorageMetadata> list(String container);
+
+   /**
+    * Lists all resources in a containers directory non-recursive.
+    *
+    * @param container what to list
+    * @param directory the directory to list
+    * @return a list that may be incomplete, depending on whether PageSet#getNextMarker is set
+    */
+   public Set<StorageMetadata> list(String container, String directory);
+
+   /**
+    * Retrieves the metadata of a {@code Blob} at location {@code container/name}
+    *
+    * @param container
+    *           container where this exists.
+    * @param name
+    *           fully qualified name relative to the container.
+    * @return null if name isn't present or the blob you intended to receive.
+    * @throws org.jclouds.blobstore.ContainerNotFoundException
+    *            if the container doesn't exist
+    */
+   BlobMetadata blobMetadata(String container, String name);
+
+   /**
+    * Retrieves a {@code Blob} representing the data at location {@code container/name}
+    *
+    *
+    * @param container
+    *           container where this exists.
+    * @param name
+    *           fully qualified name relative to the container.
+    * @return the blob you intended to receive or null, if it doesn't exist.
+    * @throws org.jclouds.blobstore.ContainerNotFoundException
+    *            if the container doesn't exist
+    */
+   Blob getBlob(String container, String name);
+
+
+   /**
+    * determines if a service-level container exists
+    */
+   boolean containerExists(String container);
+
+   /**
+    * Creates a namespace for your blobs
+    * <p/>
+    *
+    * A container is a namespace for your objects. Depending on the service, the scope can be
+    * global, identity, or sub-identity scoped. For example, in Amazon S3, containers are called
+    * buckets, and they must be uniquely named such that no-one else in the world conflicts. In
+    * other blobstores, the naming convention of the container is less strict. All blobstores allow
+    * you to list your containers and also the contents within them. These contents can either be
+    * blobs, folders, or virtual paths.
+    *
+    * @param location
+    *           some blobstores allow you to specify a location, such as US-EAST, for where this
+    *           container will exist. null will choose a default location
+    * @param container
+    *           namespace. Typically constrained to lowercase alpha-numeric and hyphens.
+    * @return true if the container was created, false if it already existed.
+    */
+   boolean createContainerInLocation(String location, String container);
+
+
+   /**
+    * This will delete the contents of a container at its root path without deleting the container
+    *
+    * @param container
+    *           what to clear
+    */
+   void clearContainer(String container);
+
+
+   /**
+    * This will delete everything inside a container recursively.
+    *
+    * @param container
+    *           what to delete
+    */
+   void deleteContainer(String container);
+
+   /**
+    * Determines if a directory exists
+    *
+    * @param container
+    *           container where the directory resides
+    * @param directory
+    *           full path to the directory
+    */
+   boolean directoryExists(String container, String directory);
+
+   /**
+    * Creates a folder or a directory marker depending on the service
+    *
+    * @param container
+    *           container to create the directory in
+    * @param directory
+    *           full path to the directory
+    */
+   void createDirectory(String container, String directory);
+
+   /**
+    * Deletes a folder or a directory marker depending on the service
+    *
+    * @param container
+    *           container to delete the directory from
+    * @param directory
+    *           full path to the directory to delete
+    */
+   void deleteDirectory(String containerName, String name);
+
+   /**
+    * Determines if a blob exists
+    *
+    * @param container
+    *           container where the blob resides
+    * @param directory
+    *           full path to the blob
+    */
+   boolean blobExists(String container, String name);
+
+
+   /**
+    * Deletes a {@code Blob} representing the data at location {@code container/name}
+    *
+    * @param container
+    *           container where this exists.
+    * @param name
+    *           fully qualified name relative to the container.
+    * @throws org.jclouds.blobstore.ContainerNotFoundException
+    *            if the container doesn't exist
+    */
+   void removeBlob(String container, String name);
+
+   /**
+    * @return a count of all blobs in the container, excluding directory markers
+    */
+   long countBlobs(String container);
+
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/blobstore/representations/ContentMetadata.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/blobstore/representations/ContentMetadata.java
@@ -1,0 +1,155 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.blobstore.representations;
+
+import com.google.common.base.Objects;
+
+import java.io.Serializable;
+import java.util.Date;
+
+import static org.jclouds.representations.Representations.dateFormat;
+
+
+public class ContentMetadata implements Serializable {
+
+   private static final long serialVersionUID = 4047812866269918734L;
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private Long length;
+      private String disposition;
+      private String encoding;
+      private String type;
+      private byte[] md5;
+      private String language;
+      private String expires;
+
+      public Builder length(final Long length) {
+         this.length = length;
+         return this;
+      }
+
+      public Builder disposition(final String disposition) {
+         this.disposition = disposition;
+         return this;
+      }
+
+      public Builder encoding(final String encoding) {
+         this.encoding = encoding;
+         return this;
+      }
+
+      public Builder type(final String type) {
+         this.type = type;
+         return this;
+      }
+
+      public Builder md5(final byte[] md5) {
+         this.md5 = md5;
+         return this;
+      }
+
+      public Builder language(final String language) {
+         this.language = language;
+         return this;
+      }
+
+      public Builder expires(final String expires) {
+         this.expires = expires;
+         return this;
+      }
+
+      public Builder expires(final Date expires) {
+         this.expires = dateFormat(expires);
+         return this;
+      }
+
+      public ContentMetadata build() {
+         return new ContentMetadata(length, disposition, encoding, type, md5, language, expires);
+      }
+   }
+
+   private final Long length;
+   private final String disposition;
+   private final String encoding;
+   private final String type;
+   private final byte[] md5;
+   private final String language;
+   private final String expires;
+
+   public ContentMetadata(Long length, String disposition, String encoding, String type, byte[] md5, String language, String expires) {
+      this.length = length;
+      this.disposition = disposition;
+      this.encoding = encoding;
+      this.type = type;
+      this.md5 = md5;
+      this.language = language;
+      this.expires = expires;
+   }
+
+   public Long getLength() {
+      return length;
+   }
+
+   public String getDisposition() {
+      return disposition;
+   }
+
+   public String getEncoding() {
+      return encoding;
+   }
+
+   public String getType() {
+      return type;
+   }
+
+   public byte[] getMd5() {
+      return md5;
+   }
+
+   public String getLanguage() {
+      return language;
+   }
+
+   public String getExpires() {
+      return expires;
+   }
+
+   public int hashCode() {
+      return Objects.hashCode(length, disposition, encoding, type, md5, language, expires);
+   }
+
+   @Override
+   public boolean equals(Object that) {
+      if (that == null)
+         return false;
+      return Objects.equal(this.toString(), that.toString());
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this).add("length", language).add("disposition", disposition).add("encoding", encoding)
+              .add("type", type).add("md5", md5).add("language", language)
+              .add("expires", expires).toString();
+   }
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/blobstore/representations/StorageMetadata.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/blobstore/representations/StorageMetadata.java
@@ -1,0 +1,183 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.blobstore.representations;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.Date;
+import java.util.Map;
+
+import static org.jclouds.representations.Representations.dateFormat;
+
+public class StorageMetadata implements Serializable {
+
+   private static final long serialVersionUID = -162484731217251198L;
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private String type;
+      private String providerId;
+      private String name;
+      private String uri;
+      private Map<String, String> userMetadata = ImmutableMap.of();
+      private String eTag;
+      private String creationDate;
+      private String lastModifiedDate;
+
+      public Builder type(final String type) {
+         this.type = type;
+         return this;
+      }
+
+      public Builder providerId(final String providerId) {
+         this.providerId = providerId;
+         return this;
+      }
+
+      public Builder name(final String name) {
+         this.name = name;
+         return this;
+      }
+
+      public Builder uri(final URI uri) {
+         if (uri != null) {
+            this.uri = uri.toString();
+         }
+         return this;
+      }
+
+      public Builder uri(final String uri) {
+         this.uri = uri;
+         return this;
+      }
+
+      public Builder userMetadata(final Map<String, String> userMetadata) {
+         this.userMetadata = ImmutableMap.copyOf(userMetadata);
+         return this;
+      }
+
+      public Builder eTag(final String eTag) {
+         this.eTag = eTag;
+         return this;
+      }
+
+      public Builder creationDate(final Date creationDate) {
+         this.creationDate = dateFormat(creationDate);
+         return this;
+      }
+
+      public Builder creationDate(final String creationDate) {
+         this.creationDate = creationDate;
+         return this;
+      }
+
+      public Builder lastModifiedDate(final Date lastModifiedDate) {
+         this.lastModifiedDate = dateFormat(lastModifiedDate);
+         return this;
+      }
+
+      public Builder lastModifiedDate(final String lastModifiedDate) {
+         this.lastModifiedDate = lastModifiedDate;
+         return this;
+      }
+
+      public StorageMetadata build() {
+         return new StorageMetadata(type, providerId, name, uri, userMetadata, eTag, creationDate, lastModifiedDate);
+      }
+
+   }
+
+   private final String type;
+   private final String providerId;
+   private final String name;
+   private final String uri;
+   private final Map<String, String> userMetadata;
+   private final String eTag;
+   private final String creationDate;
+   private final String lastModifiedDate;
+
+   public StorageMetadata(String type, String providerId, String name, String uri, Map<String, String> userMetadata,
+                          String eTag, String creationDate, String lastModifiedDate) {
+      this.type = type;
+      this.providerId = providerId;
+      this.name = name;
+      this.uri = uri;
+      this.userMetadata = userMetadata;
+      this.eTag = eTag;
+      this.creationDate = creationDate;
+      this.lastModifiedDate = lastModifiedDate;
+   }
+
+   public String getType() {
+      return type;
+   }
+
+   public String getProviderId() {
+      return providerId;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public String getUri() {
+      return uri;
+   }
+
+   public Map<String, String> getUserMetadata() {
+      return userMetadata;
+   }
+
+   public String geteTag() {
+      return eTag;
+   }
+
+   public String getCreationDate() {
+      return creationDate;
+   }
+
+   public String getLastModifiedDate() {
+      return lastModifiedDate;
+   }
+
+   public int hashCode() {
+      return Objects.hashCode(uri);
+   }
+
+   @Override
+   public boolean equals(Object that) {
+      if (that == null)
+         return false;
+      return Objects.equal(this.toString(), that.toString());
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this).add("type", type).add("providerId", providerId).add("name", name)
+              .add("userMetadata", userMetadata).add("eTag", eTag).add("creationDate", creationDate)
+              .add("lastModifiedDate", lastModifiedDate).toString();
+   }
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/ComputeService.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/ComputeService.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.representations;
+
+import org.jclouds.representations.Location;
+
+import java.util.Set;
+
+public interface ComputeService {
+   /**
+    * The list hardware profiles command shows you the options including virtual cpu count, memory,
+    * and disks. cpu count is not a portable quantity across clouds, as they are measured
+    * differently. However, it is a good indicator of relative speed within a cloud. memory is
+    * measured in megabytes and disks in gigabytes.
+    * <p/>
+    * <h3>note</h3>
+    * <p/>
+    * This is a cached collection
+    */
+   Set<Hardware> listHardwareProfiles();
+
+   /**
+    * Images define the operating system and metadata related to a node. In some clouds, Images are
+    * bound to a specific region, and their identifiers are different across these regions. For this
+    * reason, you should consider matching image requirements like operating system family with
+    * TemplateBuilder as opposed to choosing an image explicitly.
+    * <p/>
+    * <h3>note</h3>
+    * <p/>
+    * This is a cached collection
+    */
+   Set<Image> listImages();
+
+
+   /**
+    * all nodes available to the current user by id. If possible, the returned set will include
+    * {@link NodeMetadata} objects.
+    */
+   Set<NodeMetadata> listNodes();
+
+   /**
+    * The list locations command returns all the valid locations for nodes. A location has a scope,
+    * which is typically region or zone. A region is a general area, like eu-west, where a zone is
+    * similar to a datacenter. If a location has a parent, that implies it is within that location.
+    * For example a location can be a rack, whose parent is likely to be a zone.
+    * <p/>
+    * <h3>note</h3>
+    * <p/>
+    * This is a cached collection
+    */
+   Set<Location> listAssignableLocations();
+
+   /**
+    * Find an image by its id.
+    * <p/>
+    * <h3>note</h3>
+    * <p/>
+    * This is an uncached call to the backend service
+    */
+   Image getImage(String id);
+
+   /**
+    * Find a node by its id.
+    */
+   NodeMetadata getNode(String id);
+
+
+   /**
+    * @see #runScriptOnNode(String, String)
+    */
+   ExecResponse runScriptOnNode(String id, String runScript);
+
+
+   /**
+    * resume the node from suspended state,
+    * given its id.
+    *
+    * <h4>note</h4>
+    *
+    * affected nodes may not resume with the same IP address(es)
+    */
+   void resumeNode(String id);
+
+   /**
+    * suspend the node, given its id. This will result in suspended state.
+    *
+    * <h4>note</h4>
+    *
+    * affected nodes may not resume with the same IP address(es)
+    *
+    * @throws UnsupportedOperationException
+    *            if the underlying provider doesn't support suspend/resume
+    */
+   void suspendNode(String id);
+
+
+   /**
+    * destroy the node, given its id. If it is the only node in a tag set, the dependent resources
+    * will also be destroyed.
+    */
+   void destroyNode(String id);
+
+
+   /**
+    * reboot the node, given its id.
+    */
+   void rebootNode(String id);
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/ExecResponse.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/ExecResponse.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.representations;
+
+import com.google.common.base.Objects;
+
+import java.io.Serializable;
+
+public class ExecResponse implements Serializable {
+
+   private static final long serialVersionUID = -3552310550261335525L;
+
+   private final java.lang.String output;
+   private final java.lang.String error;
+   private final int exitStatus;
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private java.lang.String output;
+      private java.lang.String error;
+      private int exitStatus;
+
+      public Builder output(final String output) {
+         this.output = output;
+         return this;
+      }
+
+      public Builder error(final String error) {
+         this.error = error;
+         return this;
+      }
+
+      public Builder exitStatus(final int exitStatus) {
+         this.exitStatus = exitStatus;
+         return this;
+      }
+
+      public ExecResponse build() {
+         return new ExecResponse(output, error, exitStatus);
+      }
+   }
+
+   public ExecResponse(String output, String error, int exitStatus) {
+      this.output = output;
+      this.error = error;
+      this.exitStatus = exitStatus;
+   }
+
+   public String getOutput() {
+      return output;
+   }
+
+   public String getError() {
+      return error;
+   }
+
+   public int getExitStatus() {
+      return exitStatus;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(output, error, exitStatus);
+   }
+
+   @Override
+   public boolean equals(Object that) {
+      if (that == null)
+         return false;
+      return Objects.equal(this.toString(), that.toString());
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this).add("out", output).add("error", error).add("exitStatus", exitStatus).toString();
+   }
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/Hardware.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/Hardware.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.representations;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
+
+public class Hardware implements Serializable {
+
+   private static final long serialVersionUID = -5052972144323758255L;
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private String id;
+      private String name;
+      private Set<String> tags = ImmutableSet.of();
+      private List<Processor> processors = ImmutableList.of();
+      private int ram;
+      private List<Volume> volumes = ImmutableList.of();
+      private String hypervisor;
+
+      public Builder id(final String id) {
+         this.id = id;
+         return this;
+      }
+
+      public Builder name(final String name) {
+         this.name = name;
+         return this;
+      }
+
+      public Builder tags(final Set<String> tags) {
+         this.tags = ImmutableSet.copyOf(tags);
+         return this;
+      }
+
+      public Builder processors(final List<Processor> processors) {
+         this.processors = ImmutableList.copyOf(processors);
+         return this;
+      }
+
+      public Builder ram(final int ram) {
+         this.ram = ram;
+         return this;
+      }
+
+      public Builder volumes(final List<Volume> volumes) {
+         this.volumes = ImmutableList.copyOf(volumes);
+         return this;
+      }
+
+      public Builder hypervisor(final String hypervisor) {
+         this.hypervisor = hypervisor;
+         return this;
+      }
+
+      public Hardware build() {
+         return new Hardware(id, name, tags, processors, ram, volumes, hypervisor);
+      }
+   }
+
+   private final String id;
+   private final String name;
+   private final Set<String> tags;
+   private final List<Processor> processors;
+   private final int ram;
+   private final List<Volume> volumes;
+   private final String hypervisor;
+
+
+   public Hardware(String id, String name, Set<String> tags, List<Processor> processors, int ram, List<Volume> volumes, String hypervisor) {
+      this.id = id;
+      this.name = name;
+      this.tags = tags;
+      this.processors = processors;
+      this.ram = ram;
+      this.volumes = volumes;
+      this.hypervisor = hypervisor;
+   }
+
+   public String getId() {
+      return id;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public Set<String> getTags() {
+      return tags;
+   }
+
+   public List<Processor> getProcessors() {
+      return processors;
+   }
+
+   public int getRam() {
+      return ram;
+   }
+
+   public List<Volume> getVolumes() {
+      return volumes;
+   }
+
+   public String getHypervisor() {
+      return hypervisor;
+   }
+
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(id);
+   }
+
+   @Override
+   public boolean equals(Object that) {
+      if (that == null)
+         return false;
+      return Objects.equal(this.toString(), that.toString());
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this).add("id", id).add("name", name)
+              .add("processors", processors).add("ram", ram).add("volums", volumes).add("hypervisor", hypervisor)
+              .toString();
+   }
+}
+

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/Image.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/Image.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.representations;
+
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableSet;
+
+import java.io.Serializable;
+import java.util.Set;
+
+public class Image implements Serializable {
+
+   private static final long serialVersionUID = 1332541821219215234L;
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private String id;
+      private String name;
+      private String status;
+      private String version;
+      private String description;
+      private OperatingSystem operatingSystem;
+      private LoginCredentials defaultCredentials;
+      private Set<String> tags = ImmutableSet.of();
+
+      public Builder id(final String id) {
+         this.id = id;
+         return this;
+      }
+
+      public Builder name(final String name) {
+         this.name = name;
+         return this;
+      }
+
+      public Builder status(final String status) {
+         this.status = status;
+         return this;
+      }
+
+      public Builder tags(final Set<String> tags) {
+         this.tags = ImmutableSet.copyOf(tags);
+         return this;
+      }
+
+      public Builder operatingSystem(final OperatingSystem operatingSystem) {
+         this.operatingSystem = operatingSystem;
+         return this;
+      }
+
+      public Builder version(final String version) {
+         this.version = version;
+         return this;
+      }
+
+      public Builder description(final String description) {
+         this.description = description;
+         return this;
+      }
+
+      public Builder defaultCredentials(final LoginCredentials defaultCredentials) {
+         this.defaultCredentials = defaultCredentials;
+         return this;
+      }
+
+      public Image build() {
+         return new Image(id, name, version, description, status, operatingSystem, defaultCredentials, tags);
+      }
+
+   }
+
+   private final String id;
+   private final String name;
+   private final String version;
+   private final String description;
+   private final String status;
+   private final OperatingSystem operatingSystem;
+   private final LoginCredentials defaultCredentials;
+   private final Set<String> tags;
+
+   public Image(String id, String name, String version, String description, String status, OperatingSystem operatingSystem, LoginCredentials defaultCredentials, Set<String> tags) {
+      this.id = id;
+      this.name = name;
+      this.version = version;
+      this.description = description;
+      this.status = status;
+      this.operatingSystem = operatingSystem;
+      this.defaultCredentials = defaultCredentials;
+      this.tags = tags;
+   }
+
+   public String getId() {
+      return id;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public String getStatus() {
+      return status;
+   }
+
+   public Set<String> getTags() {
+      return tags;
+   }
+
+   public OperatingSystem getOperatingSystem() {
+      return operatingSystem;
+   }
+
+   public String getVersion() {
+      return version;
+   }
+
+   public String getDescription() {
+      return description;
+   }
+
+   public LoginCredentials getDefaultCredentials() {
+      return defaultCredentials;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(id);
+   }
+
+   @Override
+   public boolean equals(Object that) {
+      if (that == null)
+         return false;
+      return Objects.equal(this.toString(), that.toString());
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this).add("id", id).add("name", name).add("status", status)
+              .add("description", description)
+              .add("tags", tags).add("os", operatingSystem).add("version", version)
+              .add("defaultCredentials", defaultCredentials).toString();
+   }
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/LoginCredentials.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/LoginCredentials.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.representations;
+
+import com.google.common.base.Objects;
+
+import java.io.Serializable;
+import java.net.URI;
+
+public class LoginCredentials implements Serializable {
+
+   private static final long serialVersionUID = -4665781183795990721L;
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private String username;
+      private String password;
+      private String privateKey;
+      private String credentialUrl;
+      private boolean authenticateSudo;
+
+      public Builder username(final String username) {
+         this.username = username;
+         return this;
+      }
+
+      public Builder password(final String password) {
+         this.password = password;
+         return this;
+      }
+
+      public Builder privateKey(final String privateKey) {
+         this.privateKey = privateKey;
+         return this;
+      }
+
+      public Builder credentialUrl(final URI credentialUrl) {
+         if (credentialUrl != null) {
+            this.credentialUrl = credentialUrl.toString();
+         }
+         return this;
+      }
+
+      public Builder credentialUrl(final String credentialUrl) {
+         this.credentialUrl = credentialUrl;
+         return this;
+      }
+
+      public Builder authenticateSudo(final boolean authenticateSudo) {
+         this.authenticateSudo = authenticateSudo;
+         return this;
+      }
+
+      public LoginCredentials build() {
+         return new LoginCredentials(username, password, privateKey, credentialUrl, authenticateSudo);
+      }
+
+   }
+
+   private final String username;
+   private final String password;
+   private final String privateKey;
+   private final String credentialUrl;
+   private final boolean authenticateSudo;
+
+   public LoginCredentials(String username, String password, String privateKey, String credentialUrl, boolean authenticateSudo) {
+      this.username = username;
+      this.password = password;
+      this.privateKey = privateKey;
+      this.credentialUrl = credentialUrl;
+      this.authenticateSudo = authenticateSudo;
+   }
+
+   public String getUsername() {
+      return username;
+   }
+
+   public String getPassword() {
+      return password;
+   }
+
+   public String getCredentialUrl() {
+      return credentialUrl;
+   }
+
+   public boolean isAuthenticatedSudo() {
+      return authenticateSudo;
+   }
+
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(username, password, credentialUrl, authenticateSudo);
+   }
+
+   @Override
+   public boolean equals(Object that) {
+      if (that == null)
+         return false;
+      return Objects.equal(this.toString(), that.toString());
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this)
+              .add("username", username)
+              .add("hasPassword", password != null || credentialUrl != null)
+              .add("hasPrivateKey", privateKey != null)
+              .add("hasSudoPassword", authenticateSudo).toString();
+   }
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/NodeMetadata.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/NodeMetadata.java
@@ -1,0 +1,226 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jclouds.compute.representations;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Adrian Cole
+ */
+public class NodeMetadata implements Serializable {
+
+   private static final long serialVersionUID = 948372788993429243L;
+
+   private static final int DEFAULT_SSH_PORT = 22;
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private String id;
+      private String name;
+      private String description;
+      private String status;
+      private String hostname;
+      private String imageId;
+      private String locationId;
+      private int loginPort = DEFAULT_SSH_PORT;
+      private String group;
+      private Set<String> tags = ImmutableSet.of();
+      private Map<String, String> metadata = ImmutableMap.<String, String>of();
+      private LoginCredentials defaultCredentials;
+
+      public Builder id(String id) {
+         this.id = id;
+         return this;
+      }
+
+      public Builder name(String name) {
+         this.name = name;
+         return this;
+      }
+
+      public Builder description(String description) {
+         this.description = description;
+         return this;
+      }
+
+      public Builder hostname(String hostname) {
+         this.hostname = hostname;
+         return this;
+      }
+
+      public Builder status(final String status) {
+         this.status = status;
+         return this;
+      }
+
+
+      public Builder loginPort(int loginPort) {
+         this.loginPort = loginPort;
+         return this;
+      }
+
+      public Builder locationId(String locationId) {
+         this.locationId = locationId;
+         return this;
+      }
+
+      public Builder imageId(final String imageId) {
+         this.imageId = imageId;
+         return this;
+      }
+
+      public Builder group(String group) {
+         this.group = group;
+         return this;
+      }
+
+      public Builder tags(Iterable<String> tags) {
+         this.tags = ImmutableSet.copyOf(tags);
+         return this;
+      }
+
+      public Builder metadata(Map<String, String> metadata) {
+         this.metadata = ImmutableMap.copyOf(metadata);
+         return this;
+      }
+
+      public Builder defaultCredentials(final LoginCredentials defaultCredentials) {
+         this.defaultCredentials = defaultCredentials;
+         return this;
+      }
+
+      public NodeMetadata build() {
+         return new NodeMetadata(id, name, description, status, hostname, locationId, imageId, loginPort, group, tags,
+                 metadata, defaultCredentials);
+      }
+   }
+
+   public NodeMetadata(String id, String name, String description, String status, String hostname, String locationId,
+                       String imageId, int loginPort, String group, Set<String> tags,
+                       Map<String, String> metadata, LoginCredentials defaultCredentials) {
+      this.id = id;
+      this.name = name;
+      this.description = description;
+      this.status = status;
+      this.hostname = hostname;
+      this.locationId = locationId;
+      this.imageId = imageId;
+      this.loginPort = loginPort;
+      this.group = group;
+      this.tags = tags;
+      this.metadata = metadata;
+      this.defaultCredentials = defaultCredentials;
+   }
+
+   private final String id;
+   private final String name;
+   private final String description;
+   private final String status;
+   private final String hostname;
+   private final String locationId;
+   private final String imageId;
+   private final int loginPort;
+   private final String group;
+   private final Set<String> tags;
+   private final Map<String, String> metadata;
+   private final LoginCredentials defaultCredentials;
+
+   public String getId() {
+      return id;
+   }
+
+   public String getLocationId() {
+      return locationId;
+   }
+
+   public String getImageId() {
+      return imageId;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public String getDescription() {
+      return description;
+   }
+
+   public String getGroup() {
+      return group;
+   }
+
+   public String getHostname() {
+      return hostname;
+   }
+
+   public String getStatus() {
+      return status;
+   }
+
+   public int getLoginPort() {
+      return loginPort;
+   }
+
+   public Set<String> getTags() {
+      Set<String> tagSet = Sets.newHashSet();
+      for (String tag : tags) {
+         tagSet.add(tag);
+      }
+      return tagSet;
+   }
+
+   public Map<String, String> getMetadata() {
+      return Maps.newLinkedHashMap(this.metadata);
+   }
+
+   public LoginCredentials getDefaultCredentials() {
+      return defaultCredentials;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(id);
+   }
+
+   @Override
+   public boolean equals(Object that) {
+      if (that == null)
+         return false;
+      return Objects.equal(this.toString(), that.toString());
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this).add("id", id).add("name", name).add("description", description).add("status", status)
+              .add("locationId", locationId).add("imageId", imageId).add("hostname", hostname)
+              .add("group", group).add("loginPort", loginPort).add("tags", tags).add("metadata", metadata)
+              .add("defaultCredentials", defaultCredentials).toString();
+   }
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/OperatingSystem.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/OperatingSystem.java
@@ -1,0 +1,135 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.representations;
+
+import com.google.common.base.Objects;
+
+import java.io.Serializable;
+
+public class OperatingSystem implements Serializable {
+
+   private static final long serialVersionUID = 5789055455232061970L;
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private String family;
+      private String name;
+      private String arch;
+      private String version;
+      private String description;
+      private boolean is64Bit;
+
+      public Builder family(final String family) {
+         this.family = family;
+         return this;
+      }
+
+      public Builder name(final String name) {
+         this.name = name;
+         return this;
+      }
+
+      public Builder arch(final String arch) {
+         this.arch = arch;
+         return this;
+      }
+
+      public Builder version(final String version) {
+         this.version = version;
+         return this;
+      }
+
+      public Builder description(final String description) {
+         this.description = description;
+         return this;
+      }
+
+      public Builder is64Bit(final boolean is64Bit) {
+         this.is64Bit = is64Bit;
+         return this;
+      }
+
+      public OperatingSystem build() {
+         return new OperatingSystem(family, name, arch, version, description, is64Bit);
+      }
+   }
+
+   private final String family;
+   private final String name;
+   private final String arch;
+   private final String version;
+   private final String description;
+   private final boolean is64Bit;
+
+
+   public OperatingSystem(String family, String name, String arch, String version, String description, boolean is64Bit) {
+      this.family = family;
+      this.name = name;
+      this.arch = arch;
+      this.version = version;
+      this.description = description;
+      this.is64Bit = is64Bit;
+   }
+
+   public String getFamily() {
+      return family;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public String getArch() {
+      return arch;
+   }
+
+   public String getVersion() {
+      return version;
+   }
+
+   public String getDescription() {
+      return description;
+   }
+
+   public boolean isIs64Bit() {
+      return is64Bit;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(family, version, arch, is64Bit);
+   }
+
+   @Override
+   public boolean equals(Object that) {
+      if (that == null)
+         return false;
+      return Objects.equal(this.toString(), that.toString());
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this).add("family", family).add("name", name).add("arch", arch)
+              .add("version", version).add("description", description).add("is64bit", is64Bit).toString();
+   }
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/Processor.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/Processor.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.representations;
+
+import com.google.common.base.Objects;
+
+import java.io.Serializable;
+
+public class Processor implements Serializable {
+
+   private static final long serialVersionUID = -2621055948006358603L;
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private double cores;
+      private double speed;
+
+      public Builder cores(final double cores) {
+         this.cores = cores;
+         return this;
+      }
+
+      public Builder speed(final double speed) {
+         this.speed = speed;
+         return this;
+      }
+
+      public Processor build() {
+         return new Processor(cores, speed);
+      }
+
+   }
+
+   private final double cores;
+   private final double speed;
+
+   public Processor(double cores, double speed) {
+      this.cores = cores;
+      this.speed = speed;
+   }
+
+   public double getCores() {
+      return cores;
+   }
+
+   public double getSpeed() {
+      return speed;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(cores, speed);
+   }
+
+   @Override
+   public boolean equals(Object that) {
+      if (that == null)
+         return false;
+      return Objects.equal(this.toString(), that.toString());
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this).add("cores", cores).add("spped", speed).toString();
+   }
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/Volume.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/compute/representations/Volume.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.representations;
+
+import com.google.common.base.Objects;
+
+import java.io.Serializable;
+
+public class Volume implements Serializable {
+
+   private static final long serialVersionUID = -4171587668537155633L;
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private String id;
+      private String type;
+      private Float size;
+      private String device;
+      private boolean durable;
+      private boolean bootDevice;
+
+      public Builder id(final String id) {
+         this.id = id;
+         return this;
+      }
+
+      public Builder type(final String type) {
+         this.type = type;
+         return this;
+      }
+
+      public Builder size(final Float size) {
+         this.size = size;
+         return this;
+      }
+
+      public Builder device(final String device) {
+         this.device = device;
+         return this;
+      }
+
+      public Builder durable(final boolean durable) {
+         this.durable = durable;
+         return this;
+      }
+
+      public Builder bootDevice(final boolean bootDevice) {
+         this.bootDevice = bootDevice;
+         return this;
+      }
+
+      public Volume build() {
+         return new Volume(id, type, size, device, durable, bootDevice);
+      }
+
+   }
+
+   private final String id;
+   private final String type;
+   private final Float size;
+   private final String device;
+   private final boolean durable;
+   private final boolean bootDevice;
+
+   public Volume(String id, String type, Float size, String device, boolean durable, boolean bootDevice) {
+      this.id = id;
+      this.type = type;
+      this.size = size;
+      this.device = device;
+      this.durable = durable;
+      this.bootDevice = bootDevice;
+   }
+
+   public String getId() {
+      return id;
+   }
+
+   public String getType() {
+      return type;
+   }
+
+   public Float getSize() {
+      return size;
+   }
+
+   public String getDevice() {
+      return device;
+   }
+
+   public boolean isDurable() {
+      return durable;
+   }
+
+   public boolean isBootDevice() {
+      return bootDevice;
+   }
+
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(id);
+   }
+
+   @Override
+   public boolean equals(Object that) {
+      if (that == null)
+         return false;
+      return Objects.equal(this.toString(), that.toString());
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this).add("id", id).add("type", type).add("size", size)
+              .add("device", device).add("isDurable", durable).add("bootDevice", bootDevice).toString();
+   }
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/representations/ApiMetadata.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/representations/ApiMetadata.java
@@ -1,0 +1,259 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.representations;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+public class ApiMetadata implements Serializable {
+
+   private static final long serialVersionUID = 3475663463134958705L;
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private String id;
+      private String name;
+      private String endpointName;
+      private String identityName;
+      private String credentialName;
+      private String version;
+      private String defaultEndpoint;
+      private String defaultIdentity;
+      private String defaultCredential;
+      private Map<String, String> defaultProperties = ImmutableMap.of();
+      private Set<String> defaultModules = ImmutableSet.of();
+      private String documentation;
+      private String context;
+      private Set<String> views = ImmutableSet.of();
+
+      public Builder id(final String id) {
+         this.id = id;
+         return this;
+      }
+
+      public Builder name(final String name) {
+         this.name = name;
+         return this;
+      }
+
+      public Builder endpointName(final String endpointName) {
+         this.endpointName = endpointName;
+         return this;
+      }
+
+      public Builder identityName(final String identityName) {
+         this.identityName = identityName;
+         return this;
+      }
+
+      public Builder credentialName(final String credentialName) {
+         this.credentialName = credentialName;
+         return this;
+      }
+
+      public Builder version(final String version) {
+         this.version = version;
+         return this;
+      }
+
+      public Builder defaultEndpoint(final String defaultEndpoint) {
+         this.defaultEndpoint = defaultEndpoint;
+         return this;
+      }
+
+      public Builder defaultIdentity(final String defaultIdentity) {
+         this.defaultIdentity = defaultIdentity;
+         return this;
+      }
+
+      public Builder defaultCredential(final String defaultCredential) {
+         this.defaultCredential = defaultCredential;
+         return this;
+      }
+
+      public Builder defaultProperties(final Properties defaultProperties) {
+         if (defaultProperties != null) {
+            this.defaultProperties = Maps.fromProperties(defaultProperties);
+         }
+         return this;
+      }
+
+      public Builder defaultProperties(final Map<String, String> defaultProperties) {
+         this.defaultProperties = defaultProperties;
+         return this;
+      }
+
+      public Builder defaultModules(final Set<String> defaultModules) {
+         this.defaultModules = defaultModules;
+         return this;
+      }
+
+      public Builder documentation(final URI documentation) {
+         if (documentation != null) {
+            this.documentation = documentation.toString();
+         }
+         return this;
+      }
+
+      public Builder documentation(final String documentation) {
+         this.documentation = documentation;
+         return this;
+      }
+
+      public Builder context(final String context) {
+         this.context = context;
+         return this;
+      }
+
+      public Builder views(final Set<String> views) {
+         this.views = ImmutableSet.copyOf(views);
+         return this;
+      }
+
+      public ApiMetadata build() {
+         return new ApiMetadata(id, name, endpointName, identityName, credentialName, version, defaultEndpoint,
+                 defaultIdentity, defaultCredential, defaultProperties, defaultModules, documentation, context, views);
+      }
+   }
+
+   private final String id;
+   private final String name;
+   private final String endpointName;
+   private final String identityName;
+   private final String credentialName;
+   private final String version;
+   private final String defaultEndpoint;
+   private final String defaultIdentity;
+   private final String defaultCredential;
+   private final Map<String, String> defaultProperties;
+   private final Set<String> defaultModules;
+   private final String documentation;
+   private final String context;
+   private final Set<String> views;
+
+   public ApiMetadata(String id, String name, String endpointName, String identityName, String credentialName, String version,
+                      String defaultEndpoint, String defaultIdentity, String defaultCredential,
+                      Map<String, String> defaultProperties, Set<String> defaultModules, String documentation, String context,
+                      Set<String> views) {
+
+      this.id = id;
+      this.name = name;
+      this.endpointName = endpointName;
+      this.identityName = identityName;
+      this.credentialName = credentialName;
+      this.version = version;
+      this.defaultEndpoint = defaultEndpoint;
+      this.defaultIdentity = defaultIdentity;
+      this.defaultCredential = defaultCredential;
+      this.defaultProperties = defaultProperties;
+      this.defaultModules = defaultModules;
+      this.documentation = documentation;
+      this.context = context;
+      this.views = views;
+   }
+
+   public String getId() {
+      return id;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public String getEndpointName() {
+      return endpointName;
+   }
+
+   public String getIdentityName() {
+      return identityName;
+   }
+
+   public String getCredentialName() {
+      return credentialName;
+   }
+
+   public String getVersion() {
+      return version;
+   }
+
+   public String getDefaultEndpoint() {
+      return defaultEndpoint;
+   }
+
+   public String getDefaultIdentity() {
+      return defaultIdentity;
+   }
+
+   public String getDefaultCredential() {
+      return defaultCredential;
+   }
+
+   public Map<String, String> getDefaultProperties() {
+      return defaultProperties;
+   }
+
+   public Set<String> getDefaultModules() {
+      return defaultModules;
+   }
+
+   public String getDocumentation() {
+      return documentation;
+   }
+
+   public String getContext() {
+      return context;
+   }
+
+   public Set<String> getViews() {
+      return views;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(id);
+   }
+
+   @Override
+   public boolean equals(Object that) {
+      if (that == null)
+         return false;
+      return Objects.equal(this.toString(), that.toString());
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this).add("id", id).add("name", name).add("endpointName", endpointName)
+              .add("identityName", identityName).add("credentialName", credentialName).add("version", version)
+              .add("defaultEndpoint", defaultEndpoint).add("defaultIdentity", defaultIdentity)
+              .add("defaultCredential", defaultCredential).add("defaultProperties", defaultProperties).add("defaultModules", defaultModules)
+              .add("documentation", documentation).add("context", context).add("views", views).toString();
+   }
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/representations/Context.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/representations/Context.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.representations;
+
+import com.google.common.base.Objects;
+
+import java.io.Serializable;
+
+public class Context implements Serializable {
+
+   private static final long serialVersionUID = -6490025246295140657L;
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private String name;
+      private String providerId;
+      private String identity;
+
+      public Builder name(final String name) {
+         this.name = name;
+         return this;
+      }
+
+      public Builder providerId(final String providerId) {
+         this.providerId = providerId;
+         return this;
+      }
+
+      public Builder identity(final String identity) {
+         this.identity = identity;
+         return this;
+      }
+
+      public Context build() {
+         return new Context(name, providerId, identity);
+      }
+   }
+
+   private final String name;
+   private final String providerId;
+   private final String identity;
+
+
+   public Context(String name, String providerId, String identity) {
+      this.name = name;
+      this.providerId = providerId;
+      this.identity = identity;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public String getProviderId() {
+      return providerId;
+   }
+
+   public String getIdentity() {
+      return identity;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(name);
+   }
+
+   @Override
+   public boolean equals(Object that) {
+      if (that == null)
+         return false;
+      return Objects.equal(this.toString(), that.toString());
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this).add("name", name).add("providerId", providerId).add("identity", identity).toString();
+   }
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/representations/Location.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/representations/Location.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.representations;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Set;
+
+public class Location implements Serializable {
+
+   private static final long serialVersionUID = -3061687522880229207L;
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private String id;
+      private String scope;
+      private String description;
+      private String parentId;
+      private Set<String> iso3166Codes = ImmutableSet.of();
+
+      public Builder id(final String id) {
+         this.id = id;
+         return this;
+      }
+
+      public Builder scope(final String scope) {
+         this.scope = scope;
+         return this;
+      }
+
+      public Builder description(final String description) {
+         this.description = description;
+         return this;
+      }
+
+      public Builder parentId(final String parentId) {
+         this.parentId = parentId;
+         return this;
+      }
+
+      public Builder iso3166Codes(final Set<String> iso3166Codes) {
+         this.iso3166Codes = ImmutableSet.copyOf(iso3166Codes);
+         return this;
+      }
+
+      public Location build() {
+         return new Location(id, scope, description, parentId, iso3166Codes);
+      }
+
+   }
+
+   private final String id;
+   private final String scope;
+   private final String description;
+   private final String parentId;
+   private final Set<String> iso3166Codes;
+
+
+   private Location(String id, String scope, String description, String parentId, Set<String> iso3166Codes) {
+      this.id = id;
+      this.scope = scope;
+      this.description = description;
+      this.parentId = parentId;
+      this.iso3166Codes = iso3166Codes;
+   }
+
+   public String getId() {
+      return id;
+   }
+
+   public String getScope() {
+      return scope;
+   }
+
+   public String getDescription() {
+      return description;
+   }
+
+   public String getParentId() {
+      return parentId;
+   }
+
+   public Set<String> getIso3166Codes() {
+      return iso3166Codes;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(id);
+   }
+
+   @Override
+   public boolean equals(Object that) {
+      if (that == null)
+         return false;
+      return Objects.equal(this.toString(), that.toString());
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this).add("id", id).add("scope", scope).add("description", description)
+              .add("perentId", parentId).add("iso3166Codes", iso3166Codes).toString();
+   }
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/representations/ProviderMetadata.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/representations/ProviderMetadata.java
@@ -1,0 +1,264 @@
+/**
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.representations;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+public class ProviderMetadata implements Serializable {
+
+   private static final long serialVersionUID = -8444359103759144528L;
+
+   public static Builder builder() {
+      return new Builder();
+   }
+
+   public static class Builder {
+      private String id;
+      private String name;
+      private String endpointName;
+      private String identityName;
+      private String credentialName;
+      private Set<String> defaultModules = ImmutableSet.of();
+      private String documentation;
+      private Set<String> views = ImmutableSet.of();
+      private String endpoint;
+      private Map<String, String> defaultProperties = ImmutableMap.of();
+      private String console;
+      private String homePage;
+      private Set<String> linkedServices = ImmutableSet.of();
+      private Set<String> iso3166Codes = ImmutableSet.of();
+
+      public Builder id(final String id) {
+         this.id = id;
+         return this;
+      }
+
+      public Builder name(final String name) {
+         this.name = name;
+         return this;
+      }
+
+      public Builder endpointName(final String endpointName) {
+         this.endpointName = endpointName;
+         return this;
+      }
+
+      public Builder identityName(final String identityName) {
+         this.identityName = identityName;
+         return this;
+      }
+
+      public Builder credentialName(final String credentialName) {
+         this.credentialName = credentialName;
+         return this;
+      }
+
+      public Builder defaultModules(final Set<String> defaultModules) {
+         this.defaultModules = defaultModules;
+         return this;
+      }
+
+      public Builder documentation(final String documentation) {
+         this.documentation = documentation;
+         return this;
+      }
+
+      public Builder views(final Set<String> views) {
+         this.views = views;
+         return this;
+      }
+
+      public Builder endpoint(final String endpoint) {
+         this.endpoint = endpoint;
+         return this;
+      }
+
+      public Builder defaultProperties(final Properties defaultProperties) {
+         if (defaultProperties != null) {
+            this.defaultProperties = Maps.fromProperties(defaultProperties);
+         }
+         return this;
+      }
+
+      public Builder defaultProperties(final Map<String, String> defaultProperties) {
+         this.defaultProperties = defaultProperties;
+         return this;
+      }
+
+      public Builder console(final URI console) {
+         if (console != null) {
+            this.console = console.toString();
+         }
+         return this;
+      }
+
+      public Builder console(final String console) {
+         this.console = console;
+         return this;
+      }
+
+      public Builder homePage(final URI homePage) {
+         if (homePage != null) {
+            this.homePage = homePage.toString();
+         }
+         return this;
+      }
+
+      public Builder homePage(final String homePage) {
+         this.homePage = homePage;
+         return this;
+      }
+
+      public Builder linkedServices(final Set<String> linkedServices) {
+         this.linkedServices = ImmutableSet.copyOf(linkedServices);
+         return this;
+      }
+
+      public Builder iso3166Codes(final Set<String> iso3166Codes) {
+         this.iso3166Codes = ImmutableSet.copyOf(iso3166Codes);
+         return this;
+      }
+
+      public ProviderMetadata build() {
+         return new ProviderMetadata(id, name, documentation, endpointName, identityName, credentialName, defaultModules, views, endpoint, defaultProperties, console, homePage, linkedServices, iso3166Codes);
+      }
+   }
+
+   private final String id;
+   private final String name;
+   private final String documentation;
+   private final String endpointName;
+   private final String identityName;
+   private final String credentialName;
+   private final Set<String> defaultModules;
+   private final Set<String> views;
+   private final String endpoint;
+   private final Map<String, String> defaultProperties;
+   private final String console;
+   private final String homePage;
+   private final Set<String> linkedServices;
+   private final Set<String> iso3166Codes;
+
+   public ProviderMetadata(String id, String name, String documentation, String endpointName, String identityName, String credentialName,
+                           Set<String> defaultModules, Set<String> views,
+                           String endpoint, Map<String, String> defaultProperties, String console, String homePage,
+                           Set<String> linkedServices, Set<String> iso3166Codes) {
+      this.id = id;
+      this.name = name;
+      this.documentation = documentation;
+      this.endpointName = endpointName;
+      this.identityName = identityName;
+      this.credentialName = credentialName;
+      this.defaultModules = defaultModules;
+      this.views = views;
+      this.endpoint = endpoint;
+      this.defaultProperties = defaultProperties;
+      this.console = console;
+      this.homePage = homePage;
+      this.linkedServices = linkedServices;
+      this.iso3166Codes = iso3166Codes;
+   }
+
+   public String getId() {
+      return id;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public String getEndpointName() {
+      return endpointName;
+   }
+
+   public String getIdentityName() {
+      return identityName;
+   }
+
+   public String getCredentialName() {
+      return credentialName;
+   }
+
+   public Set<String> getDefaultModules() {
+      return defaultModules;
+   }
+
+   public String getDocumentation() {
+      return documentation;
+   }
+
+   public Set<String> getViews() {
+      return views;
+   }
+
+   public String getEndpoint() {
+      return endpoint;
+   }
+
+   public Map<String, String> getDefaultProperties() {
+      return defaultProperties;
+   }
+
+   public String getConsole() {
+      return console;
+   }
+
+   public String getHomePage() {
+      return homePage;
+   }
+
+   public Set<String> getLinkedServices() {
+      return ImmutableSet.copyOf(linkedServices);
+   }
+
+   public Set<String> getIso3166Codes() {
+      return ImmutableSet.copyOf(iso3166Codes);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(id);
+   }
+
+   @Override
+   public boolean equals(Object that) {
+      if (that == null)
+         return false;
+      return Objects.equal(this.toString(), that.toString());
+   }
+
+   @Override
+   public String toString() {
+      return Objects.toStringHelper(this).add("id", id).add("name", name).add("endpointName", endpointName)
+              .add("identityName", identityName).add("credentialName", credentialName).add("defaultModules", defaultModules)
+              .add("documentation", documentation).add("views", views)
+              .add("endpoint", endpoint).add("defaultProperties", defaultProperties).add("console", console)
+              .add("homePage", homePage).add("linkedServices", linkedServices).add("iso3166Codes", iso3166Codes).toString();
+   }
+}

--- a/jclouds-representations/representations-core/src/main/java/org/jclouds/representations/Representations.java
+++ b/jclouds-representations/representations-core/src/main/java/org/jclouds/representations/Representations.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.representations;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public final class Representations {
+
+   private Representations() {
+      //Utility Class
+   }
+
+   public static final DateFormat DATE_FORMAT = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss zzz");
+
+   public static String dateFormat(Date date) {
+      return date != null ? DATE_FORMAT.format(date) : "";
+   }
+}

--- a/jclouds-representations/representations-core/src/test/java/org/jclouds/blobstore/representations/StorageMetadataTest.java
+++ b/jclouds-representations/representations-core/src/test/java/org/jclouds/blobstore/representations/StorageMetadataTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.blobstore.representations;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Calendar;
+
+import static com.google.common.io.Resources.getResource;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+@Test
+public class StorageMetadataTest {
+
+   @Test
+   void testToJson() {
+      StorageMetadata storage = StorageMetadata.builder().creationDate(Calendar.getInstance().getTime()).name("file.txt")
+                                                         .uri("https://somehost/file.txt")
+                                                         .build();
+      Gson gson = new GsonBuilder().create();
+      JsonElement json = gson.toJsonTree(storage);
+      assertNotNull(json);
+      assertEquals("file.txt", json.getAsJsonObject().get("name").getAsString());
+      assertEquals("https://somehost/file.txt", json.getAsJsonObject().get("uri").getAsString());
+   }
+
+   @Test
+   void testFromJson() throws IOException {
+      Gson gson = new GsonBuilder().create();
+      String json = Resources.toString(getResource("blobstore/StorageMetadata-aws-s3-repo.json"), Charsets.UTF_8);
+      StorageMetadata storage = gson.fromJson(json, StorageMetadata.class);
+      assertNotNull(storage);
+      assertEquals("file.txt", storage.getName());
+      assertEquals("https://somecontainer.s3.amazonaws.com/file.txt", storage.getUri());
+   }
+}

--- a/jclouds-representations/representations-core/src/test/java/org/jclouds/compute/representations/HardwareTest.java
+++ b/jclouds-representations/representations-core/src/test/java/org/jclouds/compute/representations/HardwareTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.representations;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Resources;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static com.google.common.io.Resources.getResource;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+@Test
+public class HardwareTest {
+
+   @Test
+   void testToJson() {
+      Hardware hardware = Hardware.builder().id("test-hardware-profile")
+                                   .processors(ImmutableList.of(Processor.builder().cores(4).speed(2).build()))
+                                   .volumes(ImmutableList.of(Volume.builder().device("/dev/tst1").size(100f).bootDevice(true).build()))
+                                   .build();
+
+      Gson gson = new GsonBuilder().create();
+      JsonElement json = gson.toJsonTree(hardware);
+      assertNotNull(json);
+      assertEquals("test-hardware-profile", json.getAsJsonObject().get("id").getAsString());
+      assertEquals("4.0", json.getAsJsonObject().get("processors").getAsJsonArray().get(0).getAsJsonObject().get("cores").getAsString());
+      assertEquals("2.0", json.getAsJsonObject().get("processors").getAsJsonArray().get(0).getAsJsonObject().get("speed").getAsString());
+   }
+
+   @Test
+   void testFromJson() throws IOException {
+      Gson gson = new GsonBuilder().create();
+      String json = Resources.toString(getResource("compute/Hardware-stub-large.json"), Charsets.UTF_8);
+      Hardware hardware = gson.fromJson(json, Hardware.class);
+      assertNotNull(hardware);
+      assertEquals("large", hardware.getId());
+      assertEquals(1, hardware.getProcessors().size());
+      assertEquals(8.0, hardware.getProcessors().get(0).getCores());
+      assertEquals(1.0, hardware.getProcessors().get(0).getSpeed());
+   }
+}

--- a/jclouds-representations/representations-core/src/test/java/org/jclouds/compute/representations/ImageTest.java
+++ b/jclouds-representations/representations-core/src/test/java/org/jclouds/compute/representations/ImageTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.representations;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static com.google.common.io.Resources.getResource;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+@Test
+public class ImageTest {
+
+   @Test
+   void testToJson() {
+      Image image = Image.builder().id("1").name("My image").version("1.0")
+                                   .operatingSystem(OperatingSystem.builder()
+                                           .family("UBUNTU")
+                                           .is64Bit(true)
+                                           .build())
+                                   .build();
+
+      Gson gson = new GsonBuilder().create();
+      JsonElement json = gson.toJsonTree(image);
+      assertNotNull(json);
+      assertEquals("1", json.getAsJsonObject().get("id").getAsString());
+      assertEquals("My image", json.getAsJsonObject().get("name").getAsString());
+      assertEquals("UBUNTU", json.getAsJsonObject().getAsJsonObject("operatingSystem").get("family").getAsString());
+   }
+
+   @Test
+   void testFromJson() throws IOException {
+      Gson gson = new GsonBuilder().create();
+      String json = Resources.toString(getResource("compute/Image-stub-1.json"), Charsets.UTF_8);
+      Image image = gson.fromJson(json, Image.class);
+      assertNotNull(image);
+      assertEquals("1", image.getId());
+   }
+}

--- a/jclouds-representations/representations-core/src/test/java/org/jclouds/compute/representations/NodeTest.java
+++ b/jclouds-representations/representations-core/src/test/java/org/jclouds/compute/representations/NodeTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.compute.representations;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static com.google.common.io.Resources.getResource;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+@Test
+public class NodeTest {
+
+   @Test
+   void testToJson() {
+      NodeMetadata nodeMetadata = NodeMetadata.builder().id("1").name("testnode-1").group("test-group").imageId("myimage").locationId("mylocation")
+                                                        .defaultCredentials(LoginCredentials.builder()
+                                                                .username("root")
+                                                                .password("password1")
+                                                                .authenticateSudo(false)
+                                                                .build())
+
+                                                        .build();
+
+      Gson gson = new GsonBuilder().create();
+      JsonElement json = gson.toJsonTree(nodeMetadata);
+      assertNotNull(json);
+      assertEquals("1", json.getAsJsonObject().get("id").getAsString());
+      assertEquals("testnode-1", json.getAsJsonObject().get("name").getAsString());
+      assertEquals("root", json.getAsJsonObject().getAsJsonObject("defaultCredentials").get("username").getAsString());
+      assertEquals("password1", json.getAsJsonObject().getAsJsonObject("defaultCredentials").get("password").getAsString());
+   }
+
+   @Test
+   void testFromJson() throws IOException {
+      Gson gson = new GsonBuilder().create();
+      String json = Resources.toString(getResource("compute/Node-stub.json"), Charsets.UTF_8);
+      NodeMetadata node = gson.fromJson(json, NodeMetadata.class);
+      assertNotNull(node);
+      assertEquals("1", node.getId());
+      assertEquals("test-695", node.getName());
+      assertEquals("root", node.getDefaultCredentials().getUsername());
+
+   }
+}

--- a/jclouds-representations/representations-core/src/test/java/org/jclouds/representations/ApiMetadataTest.java
+++ b/jclouds-representations/representations-core/src/test/java/org/jclouds/representations/ApiMetadataTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.representations;
+
+import com.beust.jcommander.internal.Maps;
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static com.google.common.io.Resources.getResource;
+import static org.testng.Assert.assertTrue;
+
+
+@Test
+public class ApiMetadataTest {
+
+   @Test
+   void testToJson() {
+      Map<String, String> props = Maps.newHashMap();
+      props.put("key1", "value1");
+      props.put("key2", "value2");
+      props.put("key3", "value3");
+      ApiMetadata apiMetadata = ApiMetadata.builder().id("test-api").defaultIdentity("identity")
+                                           .credentialName("credential")
+                                           .documentation("http://somehost.org/doc")
+                                           .defaultProperties(props).build();
+
+      Gson gson = new GsonBuilder().create();
+      JsonElement json = gson.toJsonTree(apiMetadata);
+      assertNotNull(json);
+      assertEquals("test-api", json.getAsJsonObject().get("id").getAsString());
+      assertEquals("value1", json.getAsJsonObject().getAsJsonObject("defaultProperties").get("key1").getAsString());
+      assertEquals("value2", json.getAsJsonObject().getAsJsonObject("defaultProperties").get("key2").getAsString());
+      assertEquals("value3", json.getAsJsonObject().getAsJsonObject("defaultProperties").get("key3").getAsString());
+   }
+
+   @Test
+   void testFromJson() throws IOException {
+      Gson gson = new GsonBuilder().create();
+      String json = Resources.toString(getResource("ApiMetadata-stub.json"), Charsets.UTF_8);
+      ApiMetadata apiMetadata = gson.fromJson(json, ApiMetadata.class);
+      assertNotNull(apiMetadata);
+      assertEquals("stub", apiMetadata.getId());
+      assertEquals("stub", apiMetadata.getDefaultIdentity());
+      assertEquals("stub", apiMetadata.getDefaultCredential());
+   }
+}

--- a/jclouds-representations/representations-core/src/test/java/org/jclouds/representations/ContextTest.java
+++ b/jclouds-representations/representations-core/src/test/java/org/jclouds/representations/ContextTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.representations;
+
+import com.beust.jcommander.internal.Maps;
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static com.google.common.io.Resources.getResource;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+@Test
+public class ContextTest {
+
+   @Test
+   void testToJson() {
+      Context context = Context.builder().name("my-context").identity("me").providerId("test-provider").build();
+      Gson gson = new GsonBuilder().create();
+      JsonElement json = gson.toJsonTree(context);
+      assertNotNull(json);
+      assertEquals("my-context", json.getAsJsonObject().get("name").getAsString());
+      assertEquals("me", json.getAsJsonObject().get("identity").getAsString());
+      assertEquals("test-provider", json.getAsJsonObject().get("providerId").getAsString());
+   }
+
+   @Test
+   void testFromJson() throws IOException {
+      Gson gson = new GsonBuilder().create();
+      String json = Resources.toString(getResource("Context-stub.json"), Charsets.UTF_8);
+      Context context = gson.fromJson(json, Context.class);
+      assertNotNull(context);
+      assertEquals("stub", context.getName());
+      assertEquals("myid", context.getIdentity());
+      assertEquals("stub", context.getProviderId());
+   }
+}

--- a/jclouds-representations/representations-core/src/test/java/org/jclouds/representations/LocationTest.java
+++ b/jclouds-representations/representations-core/src/test/java/org/jclouds/representations/LocationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.representations;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Resources;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static com.google.common.io.Resources.getResource;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+@Test
+public class LocationTest {
+
+   @Test
+   void testToJson() {
+      Location location = Location.builder().id("region-1a").scope("ZONE").parentId("region-1").iso3166Codes(ImmutableSet.of("IE")).build();
+      Gson gson = new GsonBuilder().create();
+      JsonElement json = gson.toJsonTree(location);
+      assertNotNull(json);
+      assertEquals("region-1a", json.getAsJsonObject().get("id").getAsString());
+      assertEquals("ZONE", json.getAsJsonObject().get("scope").getAsString());
+      assertEquals("region-1", json.getAsJsonObject().get("parentId").getAsString());
+      assertEquals("IE", json.getAsJsonObject().get("iso3166Codes").getAsJsonArray().get(0).getAsString());
+   }
+
+   @Test
+   void testFromJson() throws IOException {
+      Gson gson = new GsonBuilder().create();
+      String json = Resources.toString(getResource("Location-aws-ec2-eu-west-1a.json"), Charsets.UTF_8);
+      Location location = gson.fromJson(json, Location.class);
+      assertNotNull(location);
+      assertEquals("eu-west-1a", location.getId());
+      assertEquals("eu-west-1", location.getParentId());
+      assertEquals("ZONE", location.getScope());
+      assertEquals(1, location.getIso3166Codes().size());
+      assertTrue(location.getIso3166Codes().contains("IE"));
+   }
+}

--- a/jclouds-representations/representations-core/src/test/java/org/jclouds/representations/ProviderMetadataTest.java
+++ b/jclouds-representations/representations-core/src/test/java/org/jclouds/representations/ProviderMetadataTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to jclouds, Inc. (jclouds) under one or more
+ * contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  jclouds licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jclouds.representations;
+
+import com.beust.jcommander.internal.Maps;
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static com.google.common.io.Resources.getResource;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+@Test
+public class ProviderMetadataTest {
+
+   @Test
+   void testToJson() {
+      Map<String, String> props = Maps.newHashMap();
+      props.put("key1", "value1");
+      props.put("key2", "value2");
+      props.put("key3", "value3");
+
+
+      ProviderMetadata providerMetadata = ProviderMetadata.builder()
+                                                          .id("test-provider").defaultProperties(props)
+                                                          .name("My test provider").build();
+
+      Gson gson = new GsonBuilder().create();
+      JsonElement json = gson.toJsonTree(providerMetadata);
+      assertNotNull(json);
+      assertEquals("test-provider", json.getAsJsonObject().get("id").getAsString());
+      assertEquals("value1", json.getAsJsonObject().getAsJsonObject("defaultProperties").get("key1").getAsString());
+      assertEquals("value2", json.getAsJsonObject().getAsJsonObject("defaultProperties").get("key2").getAsString());
+      assertEquals("value3", json.getAsJsonObject().getAsJsonObject("defaultProperties").get("key3").getAsString());
+   }
+
+   @Test
+   void testFromJson() throws IOException {
+      Gson gson = new GsonBuilder().create();
+      String json = Resources.toString(getResource("ProviderMetadata-aws-ec2.json"), Charsets.UTF_8);
+      ProviderMetadata providerMetadata = gson.fromJson(json, ProviderMetadata.class);
+      assertNotNull(providerMetadata);
+      assertEquals("aws-ec2", providerMetadata.getId());
+      assertTrue(providerMetadata.getDefaultModules().contains("org.jclouds.aws.ec2.config.AWSEC2RestClientModule"));
+   }
+}

--- a/jclouds-representations/representations-core/src/test/resources/ApiMetadata-stub.json
+++ b/jclouds-representations/representations-core/src/test/resources/ApiMetadata-stub.json
@@ -1,0 +1,34 @@
+{
+    defaultEndpoint: "stub",
+    credentialName: null,
+    builderVersion: "",
+    defaultProperties: {
+        jclouds.max-connections-per-host: "0",
+        jclouds.user-threads: "0",
+        jclouds.connection-timeout: "60000",
+        jclouds.max-connections-per-context: "20",
+        jclouds.iso3166-codes: "",
+        jclouds.max-connection-reuse: "75",
+        jclouds.payloads.pretty-print: "true",
+        jclouds.scheduler-threads: "10",
+        jclouds.io-worker-threads: "20",
+        jclouds.max-session-failures: "2",
+        jclouds.session-interval: "60",
+        jclouds.so-timeout: "60000"
+},
+version: "",
+id: "stub",
+defaultCredential: "stub",
+defaultIdentity: "stub",
+views: [
+"org.jclouds.compute.ComputeServiceContext"
+],
+name: "in-memory (Stub) API",
+documentation: "http://www.jclouds.org/documentation/userguide/compute",
+context: "interface org.jclouds.Context",
+identityName: "Unused",
+endpointName: "https endpoint",
+defaultModules: [
+"org.jclouds.compute.stub.config.StubComputeServiceContextModule"
+]
+}

--- a/jclouds-representations/representations-core/src/test/resources/Context-stub.json
+++ b/jclouds-representations/representations-core/src/test/resources/Context-stub.json
@@ -1,0 +1,5 @@
+{
+    identity: "myid",
+    name: "stub",
+    providerId: "stub"
+}

--- a/jclouds-representations/representations-core/src/test/resources/Location-aws-ec2-eu-west-1a.json
+++ b/jclouds-representations/representations-core/src/test/resources/Location-aws-ec2-eu-west-1a.json
@@ -1,0 +1,9 @@
+{
+    id: "eu-west-1a",
+    parentId: "eu-west-1",
+    scope: "ZONE",
+    iso3166Codes: [
+        "IE"
+    ],
+    description: "eu-west-1a"
+}

--- a/jclouds-representations/representations-core/src/test/resources/ProviderMetadata-aws-ec2.json
+++ b/jclouds-representations/representations-core/src/test/resources/ProviderMetadata-aws-ec2.json
@@ -1,0 +1,72 @@
+{
+    credentialName: "Secret Access Key",
+    linkedServices: [
+        "aws-ec2",
+        "aws-elb",
+        "aws-cloudwatch",
+        "aws-s3",
+        "aws-simpledb"
+    ],
+    endpoint: "https://ec2.us-east-1.amazonaws.com",
+    defaultProperties: {
+        jclouds.template: "osFamily=AMZN_LINUX,os64Bit=true",
+        jclouds.region.ap-southeast-2.iso3166-codes: "AU-NSW",
+        jclouds.region.eu-west-1.iso3166-codes: "IE",
+        jclouds.iso3166-codes: "US-VA,US-CA,US-OR,BR-SP,IE,SG,AU-NSW,JP-13",
+        jclouds.scheduler-threads: "10",
+        jclouds.compute.timeout.node-suspended: "120000",
+        jclouds.io-worker-threads: "20",
+        jclouds.ssh.max-retries: "7",
+        jclouds.ssh.retry-auth: "true",
+        jclouds.ec2.timeout.securitygroup-present: "500",
+        jclouds.max-connections-per-context: "20",
+        jclouds.region.sa-east-1.iso3166-codes: "BR-SP",
+        jclouds.ec2.auto-allocate-elastic-ips: "false",
+        jclouds.ec2.cc-ami-query: "virtualization-type=hvm;architecture=x86_64;owner-id=137112412989,099720109477;hypervisor=xen;state=available;image-type=machine;root-device-type=ebs",
+        jclouds.payloads.pretty-print: "true",
+        jclouds.session-interval: "60",
+        jclouds.ec2.generate-instance-names: "true",
+        jclouds.so-timeout: "60000",
+        jclouds.region.us-east-1.iso3166-codes: "US-VA",
+        jclouds.region.us-west-2.iso3166-codes: "US-OR",
+        jclouds.user-threads: "0",
+        jclouds.region.us-west-1.iso3166-codes: "US-CA",
+        jclouds.compute.resourcename-delimiter: "#",
+        jclouds.regions: "us-east-1,us-west-1,us-west-2,sa-east-1,eu-west-1,ap-southeast-1,ap-southeast-2,ap-northeast-1",
+        jclouds.aws.auth.tag: "AWS",
+        jclouds.max-connections-per-host: "0",
+        jclouds.region.ap-northeast-1.iso3166-codes: "JP-13",
+        jclouds.connection-timeout: "60000",
+        jclouds.ec2.ami-query: "owner-id=137112412989,801119661308,063491364108,099720109477,411009282317;state=available;image-type=machine",
+        jclouds.max-connection-reuse: "75",
+        jclouds.ec2.cc-regions: "us-east-1,us-west-2,eu-west-1",
+        jclouds.max-session-failures: "2",
+        jclouds.aws.header.tag: "amz",
+        jclouds.region.ap-southeast-1.iso3166-codes: "SG"
+    },
+    id: "aws-ec2",
+    console: "https://console.aws.amazon.com/ec2/home",
+    iso3166Codes: [
+        "US-VA",
+        "US-CA",
+        "US-OR",
+        "BR-SP",
+        "IE",
+        "SG",
+        "AU-NSW",
+        "JP-13"
+    ],
+    views: [
+    "org.jclouds.aws.ec2.compute.AWSEC2ComputeServiceContext"
+    ],
+    name: "Amazon Elastic Compute Cloud (EC2)",
+    documentation: "http://docs.amazonwebservices.com/AWSEC2/latest/APIReference",
+    identityName: "Access Key ID",
+    endpointName: "https endpoint",
+    defaultModules: [
+        "org.jclouds.aws.ec2.config.AWSEC2RestClientModule",
+        "org.jclouds.ec2.compute.config.EC2ResolveImagesModule",
+        "org.jclouds.aws.ec2.compute.config.AWSEC2ComputeServiceContextModule"
+    ],
+    homePage: "http://aws.amazon.com/ec2"
+}

--- a/jclouds-representations/representations-core/src/test/resources/blobstore/Blob-aws-s2-test.json
+++ b/jclouds-representations/representations-core/src/test/resources/blobstore/Blob-aws-s2-test.json
@@ -1,0 +1,47 @@
+{
+    allHeaders: {
+        x-amz-request-id: [
+        "DFE7296CE8E01DFC"
+        ],
+        ETag: [
+        ""27cd600dadfa81d502e2cd1491b00725""
+        ],
+        Date: [
+        "Sun, 14 Apr 2013 20:04:41 GMT"
+        ],
+        x-amz-id-2: [
+        "vH5MToKQVwgYTzAK771VQkWdv5DETmLC1xYjBeEsNz3WVauTL+MjiDhE/wvIJ7mo"
+        ],
+        Last-Modified: [
+        "Wed, 09 Jan 2013 20:48:14 GMT"
+        ],
+        Accept-Ranges: [
+        "bytes"
+        ],
+        Server: [
+        "AmazonS3"
+        ],
+        Cache-Control: [
+        "no-cache"
+        ]
+       },
+blobMetadata: {
+        creationDate: null,
+        name: "pom.xml",
+        lastModifiedDate: "2013-01-09T22:48:14+02:00",
+        providerId: null,
+        userMetadata: { },
+        publicUri: null,
+        type: "BLOB",
+        uri: "https://somecontainer.s3.amazonaws.com/file.txt",
+        contentMetadata: {
+        expires: null,
+        md5: null,
+        encoding: null,
+        length: 64021,
+        language: null,
+        type: "application/unknown",
+        disposition: null
+       }
+}
+}

--- a/jclouds-representations/representations-core/src/test/resources/blobstore/StorageMetadata-aws-s3-repo.json
+++ b/jclouds-representations/representations-core/src/test/resources/blobstore/StorageMetadata-aws-s3-repo.json
@@ -1,0 +1,9 @@
+{
+    creationDate: null,
+    name: "file.txt",
+    lastModifiedDate: "2013-01-09T22:48:14+02:00",
+    providerId: null,
+    userMetadata: { },
+    type: "BLOB",
+    uri: "https://somecontainer.s3.amazonaws.com/file.txt"
+}

--- a/jclouds-representations/representations-core/src/test/resources/compute/Hardware-stub-large.json
+++ b/jclouds-representations/representations-core/src/test/resources/compute/Hardware-stub-large.json
@@ -1,0 +1,23 @@
+{
+    tags: [ ],
+    id: "large",
+    ram: 15360,
+    hypervisor: null,
+    name: "large",
+    volumes: [
+        {
+            id: null,
+            bootDevice: true,
+            device: null,
+            durable: false,
+            type: "LOCAL",
+            size: 1690
+        }
+    ],
+    processors: [
+        {
+            speed: 1,
+            cores: 8
+        }
+    ]
+}

--- a/jclouds-representations/representations-core/src/test/resources/compute/Image-aws-5e7de437.json
+++ b/jclouds-representations/representations-core/src/test/resources/compute/Image-aws-5e7de437.json
@@ -1,0 +1,22 @@
+{
+    tags: [ ],
+    id: "us-east-1/ami-5e7de437",
+    operatingSystem: {
+        arch: "paravirtual",
+        family: "AMZN_LINUX",
+        description: null,
+        name: null,
+        is64Bit: true,
+        version: "minimal-pv-2013.03.rc-1"
+    },
+    defaultCredentials: {
+        username: "ec2-user",
+        authenticatedSudo: false,
+        credentialUrl: null,
+        password: null
+    },
+    status: "AVAILABLE",
+    description: "Amazon Linux AMI x86_64 EBS",
+    name: "amzn-ami-minimal-pv-2013.03.rc-1.x86_64-ebs",
+    version: "minimal-pv-2013.03.rc-1"
+}

--- a/jclouds-representations/representations-core/src/test/resources/compute/Image-stub-1.json
+++ b/jclouds-representations/representations-core/src/test/resources/compute/Image-stub-1.json
@@ -1,0 +1,22 @@
+{
+    tags: [ ],
+    id: "1",
+    operatingSystem: {
+        arch: null,
+        family: "SUSE",
+        description: null,
+        name: "stub suse true",
+        is64Bit: true,
+        version: ""
+    },
+    defaultCredentials: {
+        username: "root",
+        authenticatedSudo: false,
+        credentialUrl: null,
+        password: null
+    },
+    status: "AVAILABLE",
+    description: "stub suse true",
+    name: "SUSE",
+    version: null
+}

--- a/jclouds-representations/representations-core/src/test/resources/compute/Node-stub.json
+++ b/jclouds-representations/representations-core/src/test/resources/compute/Node-stub.json
@@ -1,0 +1,19 @@
+{
+    tags: [ ],
+    id: "1",
+    imageId: "34",
+    defaultCredentials: {
+        username: "root",
+        authenticatedSudo: false,
+        credentialUrl: null,
+        password: "password1"
+    },
+    status: "RUNNING",
+    description: null,
+    name: "test-695",
+    locationId: "stub",
+    hostname: "testhost",
+    loginPort: 22,
+    group: "testgroup",
+    metadata: { }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,8 @@
        <module>fgcp-au</module>
        <module>fgcp-de</module>
        <module>abiquo</module>
+       <module>jclouds-representations</module>
+       <module>jclouds-management</module>
     </modules>
 
     <build>


### PR DESCRIPTION
This pull request add jclouds-dto to labs.

This project intends to provide "data transfer objects" for most of the jclouds domain objects.
The idea is to have objects that are easily serialized so that they can be used for exposing jcouds to jmx, etc.

The project consists of 2 modules:
i) dto-core: Which provides the dtos
ii) dto-converters which provides functions for converting the domain objects to dtos.

Note: In some cases I am using an ImutableSet builder, over guavas lazy iterables (e.g. transfomed iterables), mostly because the lazy stuff had some issues with serialization. I am not aware of any better way (an other idea is to create a set manually?). 
