### PR TITLE
Removing explicit versions that match the inherited ones

### DIFF
--- a/abiquo/pom.xml
+++ b/abiquo/pom.xml
@@ -6,10 +6,8 @@
         <artifactId>jclouds-labs</artifactId>
         <version>1.7.0-SNAPSHOT</version>
     </parent>
-    
     <groupId>org.jclouds.labs</groupId>
     <artifactId>abiquo</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <name>jclouds Abiquo api</name>
     <description>jclouds components to access an implementation of Abiquo</description>
     <packaging>bundle</packaging>

--- a/aws-elb/pom.xml
+++ b/aws-elb/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>org.jclouds.labs</groupId>
     <artifactId>aws-elb</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <name>jclouds Amazon Elastic Load Balancer provider</name>
     <description>Elastic Load Balancer implementation targeted to Amazon Web Services</description>
     <packaging>bundle</packaging>

--- a/aws-iam/pom.xml
+++ b/aws-iam/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>org.jclouds.labs</groupId>
     <artifactId>aws-iam</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <name>jclouds Amazon Identity and Access Management (IAM) provider</name>
     <description>Identity and Access Management (IAM) to Amazon Web Services</description>
     <packaging>bundle</packaging>

--- a/aws-rds/pom.xml
+++ b/aws-rds/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>org.jclouds.labs</groupId>
     <artifactId>aws-rds</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <name>jclouds Amazon Relational Database Service provider</name>
     <description>Relational Database Service implementation targeted to Amazon Web Services</description>
     <packaging>bundle</packaging>

--- a/azure-management/pom.xml
+++ b/azure-management/pom.xml
@@ -28,7 +28,6 @@
   </parent>
   <groupId>org.jclouds.labs</groupId>
   <artifactId>azure-management</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jcloud azure-management api</name>
   <description>jclouds components to access an implementation of Azure Management</description>
   <packaging>bundle</packaging>

--- a/carrenza-vcloud-director/pom.xml
+++ b/carrenza-vcloud-director/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>org.jclouds.labs</groupId>
     <artifactId>carrenza-vcloud-director</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <name>jclouds Carrenza vCloud Director provider</name>
     <description>vCloud Director implementation targeted to Carrenza</description>
     <packaging>bundle</packaging>

--- a/cdmi/pom.xml
+++ b/cdmi/pom.xml
@@ -28,7 +28,6 @@
   </parent>
   <groupId>org.jclouds.labs</groupId>
   <artifactId>cdmi</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jcloud cdmi api</name>
   <description>jclouds components to access an implementation of SNIA CDMI</description>
   <packaging>bundle</packaging>

--- a/cloudstack-ec2/pom.xml
+++ b/cloudstack-ec2/pom.xml
@@ -28,7 +28,6 @@
   </parent>
   <groupId>org.jclouds.labs</groupId>
   <artifactId>cloudstack-ec2</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jclouds CloudStack EC2 api</name>
   <description>EC2 implementation based on CloudStack</description>
   <packaging>bundle</packaging>

--- a/dmtf/pom.xml
+++ b/dmtf/pom.xml
@@ -28,7 +28,6 @@
   </parent>
   <groupId>org.jclouds.labs</groupId>
   <artifactId>dmtf</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jclouds dmtf domain objects</name>
   <description>jclouds implementation of DMTF OVF and CIM domain objects</description>
   <packaging>bundle</packaging>

--- a/elb/pom.xml
+++ b/elb/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>org.jclouds.labs</groupId>
     <artifactId>elb</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <name>jcloud elb api</name>
     <description>jclouds components to access an implementation of Elastic Load Balancer</description>
     <packaging>bundle</packaging>

--- a/fgcp-au/pom.xml
+++ b/fgcp-au/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>org.jclouds.labs</groupId>
     <artifactId>fgcp-au</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <name>jclouds Fujitsu Global Cloud Platform AU provider</name>
     <description>jclouds components to access Fujitsu Global Cloud Platform in Australia</description>
     <url>http://globalcloud.fujitsu.com.au</url>

--- a/fgcp-de/pom.xml
+++ b/fgcp-de/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>org.jclouds.labs</groupId>
     <artifactId>fgcp-de</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <name>jclouds Fujitsu Global Cloud Platform DE provider</name>
     <description>jclouds components to access Fujitsu Global Cloud Platform in Germany</description>
     <url>http://globalcloud.de.fujitsu.com</url>

--- a/fgcp/pom.xml
+++ b/fgcp/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>org.jclouds.labs</groupId>
     <artifactId>fgcp</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <name>jclouds Fujitsu Global Cloud Platform</name>
     <description>jclouds components to access Fujitsu Global Cloud Platform</description>
 

--- a/google-compute-engine/pom.xml
+++ b/google-compute-engine/pom.xml
@@ -27,7 +27,6 @@
     </parent>
     <groupId>org.jclouds.labs</groupId>
     <artifactId>google-compute-engine</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <name>jclouds Google Compute Engine provider</name>
     <description>jclouds components to access GoogleCompute</description>
 

--- a/greenqloud-compute/pom.xml
+++ b/greenqloud-compute/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>org.jclouds.labs</groupId>
     <artifactId>greenqloud-compute</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <name>jclouds Greenqloud compute provider</name>
     <description>Compute implementation targeted to Greenqloud Web Services</description>
     <packaging>bundle</packaging>

--- a/greenqloud-storage/pom.xml
+++ b/greenqloud-storage/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>org.jclouds.labs</groupId>
     <artifactId>greenqloud-storage</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <name>jclouds GreenQloud Simple Storage Service (S3) provider</name>
     <description>Simple Storage Service (S3) implementation targeted to GreenQloud Web Services</description>
     <packaging>bundle</packaging>

--- a/iam/pom.xml
+++ b/iam/pom.xml
@@ -28,7 +28,6 @@
   </parent>
   <groupId>org.jclouds.labs</groupId>
   <artifactId>iam</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jcloud iam api</name>
   <description>jclouds components to access an implementation of Identity and Access Management (IAM)</description>
   <packaging>bundle</packaging>

--- a/jenkins/pom.xml
+++ b/jenkins/pom.xml
@@ -28,7 +28,6 @@
   </parent>
   <groupId>org.jclouds.labs</groupId>
   <artifactId>jenkins</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jcloud jenkins api</name>
   <description>jclouds components to access an implementation of Jenkins</description>
   <packaging>bundle</packaging>

--- a/joyent-cloudapi/pom.xml
+++ b/joyent-cloudapi/pom.xml
@@ -28,7 +28,6 @@
   </parent>
   <groupId>org.jclouds.labs</groupId>
   <artifactId>joyent-cloudapi</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jcloud joyent-cloudapi api</name>
   <description>jclouds components to access an implementation of Joyent SDC</description>
   <packaging>bundle</packaging>

--- a/joyentcloud/pom.xml
+++ b/joyentcloud/pom.xml
@@ -28,7 +28,6 @@
   </parent>
   <groupId>org.jclouds.labs</groupId>
   <artifactId>joyentcloud</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jcloud joyentcloud api</name>
   <description>jclouds components to access the Joyent Cloud</description>
   <packaging>bundle</packaging>

--- a/nodepool/pom.xml
+++ b/nodepool/pom.xml
@@ -28,7 +28,6 @@
   </parent>
   <groupId>org.jclouds.labs</groupId>
   <artifactId>nodepool</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jcloud nodepool api</name>
   <packaging>bundle</packaging>
 

--- a/oauth/pom.xml
+++ b/oauth/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>org.jclouds.labs</groupId>
     <artifactId>oauth</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <name>jclouds OAuth core</name>
     <description>jclouds components to access OAuth</description>
 

--- a/openstack/openstack-glance/pom.xml
+++ b/openstack/openstack-glance/pom.xml
@@ -28,7 +28,6 @@
   </parent>
   <groupId>org.jclouds.labs</groupId>
   <artifactId>openstack-glance</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jclouds openstack-glance api</name>
   <description>jclouds components to access an implementation of OpenStack Glance</description>
   <packaging>bundle</packaging>

--- a/openstack/openstack-quantum/pom.xml
+++ b/openstack/openstack-quantum/pom.xml
@@ -28,7 +28,6 @@
   </parent>
   <groupId>org.jclouds.labs</groupId>
   <artifactId>openstack-quantum</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jclouds openstack-quantum api</name>
   <description>jclouds components to access an implementation of OpenStack Quantum</description>
   <packaging>bundle</packaging>

--- a/openstack/openstack-swift/pom.xml
+++ b/openstack/openstack-swift/pom.xml
@@ -28,7 +28,6 @@
   </parent>
   <groupId>org.jclouds.labs</groupId>
   <artifactId>openstack-swift</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jclouds openstack-swift api</name>
   <description>jclouds components to access an implementation of OpenStack Swift</description>
   <packaging>bundle</packaging>

--- a/openstack/pom.xml
+++ b/openstack/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>org.jclouds.labs</groupId>
     <artifactId>jclouds-labs-openstack</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>jclouds labs openstack</name>
     <modules>

--- a/opsource-servers/pom.xml
+++ b/opsource-servers/pom.xml
@@ -28,7 +28,6 @@
   </parent>
   <groupId>org.jclouds.labs</groupId>
   <artifactId>opsource-servers</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jcloud opsource-servers api</name>
   <description>jclouds components to access an implementation of OpSource Cloud Servers</description>
   <packaging>bundle</packaging>

--- a/rackspace-clouddns/pom.xml
+++ b/rackspace-clouddns/pom.xml
@@ -26,9 +26,7 @@
     <artifactId>jclouds-labs</artifactId>
     <version>1.7.0-SNAPSHOT</version>
   </parent>
-
   <artifactId>rackspace-clouddns</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jclouds rackspace clouddns api</name>
   <description>jclouds components for Rackspace Cloud DNS</description>
   <packaging>bundle</packaging>

--- a/rds/pom.xml
+++ b/rds/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>org.jclouds.labs</groupId>
     <artifactId>rds</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <name>jcloud rds api</name>
     <description>jclouds components to access an implementation of Relational Database Service</description>
     <packaging>bundle</packaging>

--- a/savvis-symphonyvpdc/pom.xml
+++ b/savvis-symphonyvpdc/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>org.jclouds.provider</groupId>
     <artifactId>savvis-symphonyvpdc</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <name>jclouds savvis-vpdc vpdc</name>
     <description>jclouds components to access Savvis Symphony VPDC</description>
     <packaging>bundle</packaging>

--- a/smartos-ssh/pom.xml
+++ b/smartos-ssh/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>org.jclouds.labs</groupId>
     <artifactId>smartos-ssh</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
     <name>smartos ssh api</name>
     <description>jclouds components to access SmartOS over SSH</description>
     <packaging>bundle</packaging>

--- a/vcloud-director/pom.xml
+++ b/vcloud-director/pom.xml
@@ -28,7 +28,6 @@
   </parent>
   <groupId>org.jclouds.labs</groupId>
   <artifactId>vcloud-director</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jclouds vcloud-director api</name>
   <description>jclouds components to access an implementation of VMware vCloud Director 1.5+</description>
   <packaging>bundle</packaging>

--- a/virtualbox/pom.xml
+++ b/virtualbox/pom.xml
@@ -28,7 +28,6 @@
   </parent>
   <groupId>org.jclouds.labs</groupId>
   <artifactId>virtualbox</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
   <name>jcloud virtualbox api</name>
   <description>jclouds components to access an implementation of virtualbox</description>
   <packaging>bundle</packaging>


### PR DESCRIPTION
These were added in 1ddd0592 but should always match the version inherited from the parent, so shouldn't be necessary..?
